### PR TITLE
Update OCI source label

### DIFF
--- a/bootc/Containerfile
+++ b/bootc/Containerfile
@@ -4,7 +4,7 @@ FROM ${FEDORA_BOOTC_BASE}
 LABEL containers.bootc=1 \
   org.opencontainers.image.title="tank-os" \
   org.opencontainers.image.description="Fedora bootc image for OpenClaw on rootless Podman" \
-  org.opencontainers.image.source="https://github.com/sallyom/tank-os"
+  org.opencontainers.image.source="https://github.com/LobsterTrap/tank-os"
 
 ARG OPENCLAW_UID=1000
 ARG OPENCLAW_GID=1000


### PR DESCRIPTION
## Summary
- point the OCI `org.opencontainers.image.source` label at the public upstream repository
- replace the current `sallyom/tank-os` URL, which returns 404

## Verification
- `git diff HEAD^ HEAD --check`
- confirmed `https://github.com/LobsterTrap/tank-os` resolves via the GitHub API
- confirmed `https://github.com/sallyom/tank-os` returns 404 via the GitHub API