### PR TITLE
Add clone step to the agent prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.img
 *.zst
 /.tmp/
+out-tank-os/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.zst
 /.tmp/
 out-tank-os/
+.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ Goals:
 - Clone the repository `git clone https://github.com/LobsterTrap/tank-os.git` and work from there (cd)
 - Build or use the published bootc image `quay.io/sallyom/tank-os:latest` for arm64 or amd64.
 - Build a QCOW2 disk image with the Podman Desktop BootC extension or manual bootc-image-builder flow.
-- Start the disk image as a Linux VM on macOS/Podman Desktop.
+- Start the disk image as a Linux VM. On macOS, QEMU with user-mode networking is the most reliable path: `qemu-system-aarch64 -machine virt,highmem=on -accel hvf -cpu host -smp 4 -m 4096 -drive file=disk.qcow2,format=qcow2,if=virtio -drive if=pflash,format=raw,unit=0,file=$(brew --prefix)/share/qemu/edk2-aarch64-code.fd,readonly=on -device virtio-net-pci,netdev=net0 -netdev user,id=net0,hostfwd=tcp::2222-:22 -nographic`. Podman Desktop BootC extension or UTM also work.
+- If the default 10 GB disk is too small for the OpenClaw container image (~3.5 GB), resize before first boot: `qemu-img resize disk.qcow2 20G`. XFS grows automatically on next boot.
 - SSH in as `openclaw`, verify `sudo -n true`, `sudo bootc status`, `systemctl --user status openclaw.service`, and `podman ps`.
-- If the VM is running under Podman Desktop/macadam, find the forwarded SSH port from the `gvproxy` process and use `ssh -i ~/.ssh/id_ed25519 -p <port> openclaw@localhost`.
+- If the VM is running under Podman Desktop/macadam, find the forwarded SSH port from the `gvproxy` process and use `ssh -i ~/.ssh/id_ed25519 -p <port> openclaw@localhost`. For QEMU with the hostfwd above, use `ssh -i ~/.ssh/id_ed25519 -p 2222 openclaw@localhost`.
 - Use an SSH tunnel to open the UI from the host browser: `ssh -N -i ~/.ssh/id_ed25519 -p <port> -L 18789:127.0.0.1:18789 -L 18790:127.0.0.1:18790 openclaw@localhost`, then browse to `http://127.0.0.1:18789`.
 - Print the dashboard URL from the VM with `openclaw dashboard --no-open`.
 - Configure model provider and service-gator credentials using rootless Podman secrets as the `openclaw` user, then run `tank-openclaw-secrets`.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Use this prompt with a coding agent to get oriented and run the local VM flow:
 I am working in the tank-os repo. This repo builds a Fedora bootc image that runs OpenClaw as a rootless Podman Quadlet owned by the `openclaw` user. Please help me get a local smoke test running.
 
 Goals:
+- Clone the repository `git clone https://github.com/LobsterTrap/tank-os.git` and work from there (cd)
 - Build or use the published bootc image `quay.io/sallyom/tank-os:latest` for arm64 or amd64.
 - Build a QCOW2 disk image with the Podman Desktop BootC extension or manual bootc-image-builder flow.
 - Start the disk image as a Linux VM on macOS/Podman Desktop.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ Goals:
 - Print the dashboard URL from the VM with `openclaw dashboard --no-open`.
 - Configure model provider and service-gator credentials using rootless Podman secrets as the `openclaw` user, then run `tank-openclaw-secrets`.
 
+Post-boot operations (once SSH'd in as `openclaw`):
+- The host `openclaw` command delegates into the running container. Use it for all CLI operations: `openclaw gateway status --deep`, `openclaw doctor`, `openclaw dashboard --no-open`, `openclaw devices list`.
+- Check service health: `systemctl --user status openclaw.service`, `podman ps`, `podman logs -f openclaw`.
+- If the OpenClaw service fails on first boot with a permission error on `~/.openclaw`, fix ownership with `sudo chown -R openclaw:openclaw ~/.openclaw` and restart: `systemctl --user restart openclaw.service`.
+- If the service times out pulling the ~3.5 GB container image, pull manually first: `podman pull ghcr.io/openclaw/openclaw:latest`, then restart the service.
+- Edit OpenClaw config and workspace files directly under `~/.openclaw/`. Restart the service after config changes: `systemctl --user restart openclaw.service`.
+- Create model provider secrets: `printf '%s' "$ANTHROPIC_API_KEY" | podman secret create anthropic_api_key -`, then run `tank-openclaw-secrets` and restart the service. Supported secret names: `anthropic_api_key`, `openai_api_key`, `gemini_api_key`, `google_api_key`, `openrouter_api_key`.
+- Create service-gator secrets the same way: `printf '%s' "$GH_TOKEN" | podman secret create gh_token -`. Edit scopes at `~/.config/service-gator/scopes.json`. Then `tank-openclaw-secrets && systemctl --user restart service-gator.service`.
+- For low-level debugging, open a shell inside the container: `podman exec -it openclaw sh`.
+
 Constraints:
 - Do not bake private keys or API keys into the image.
 - Keep OpenClaw state editable under `~openclaw/.openclaw`.


### PR DESCRIPTION
The agent prompt in the README tells a coding agent how to get oriented and run the local VM flow, but it assumes the agent is already inside the repo. This adds the clone + cd step as the first goal so the prompt works when pasted cold into a fresh session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified setup: start from the project repo, added a QEMU user-mode networking example (SSH forwarded to port 2222) while preserving GUI alternatives, added disk-resize guidance and note that filesystem grows on next boot, and added a “Post-boot operations” section with CLI wrapper usage, service/health checks, permission-failure recovery, image-pull timeout recovery, config edit & service restart, secret creation, and container shell debugging.
* **Chores**
  * Ignored additional generated/output paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->