### PR TITLE
Install qemu-guest-agent

### DIFF
--- a/bootc/Containerfile
+++ b/bootc/Containerfile
@@ -17,6 +17,7 @@ RUN set -eux; \
       openssh-server \
       podman \
       python3 \
+      qemu-guest-agent \
       shadow-utils \
       sudo \
       vim-enhanced; \


### PR DESCRIPTION
To allow the tank-os image to run in a virtual enviroment more seamlessly, it would be useful to have qemu-guest-agent in the base image. The systemd service is left off, so it won't activate in physical deployments, so this should only affect virtual installations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build dependencies to improve VM integration and performance in virtualized environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->