### PR TITLE
feat: add comprehensive CI/CD pipeline with signing and attestation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "docker"
+    directory: "/bootc"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,254 @@
+name: Build and Release Container Image
+
+on:
+  push:
+    tags:
+    - v*
+
+env:
+  REGISTRY_USER: ${{ vars.REGISTRY_USER }}
+  IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY }}
+  IMAGE: tank-os
+  COSIGN_PUBLIC_KEY: ${{ vars.COSIGN_PUBLIC_KEY }}
+  RELEASE_REGISTRY: ${{ vars.RELEASE_REGISTRY }}
+
+permissions: read-all
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Prepare platform pair
+      run: |
+        platform=${{ matrix.platform }}
+        echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Parse version
+      id: parse_version
+      run: |
+        VERSION=${GITHUB_REF#refs/tags/v}
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+    - name: Log in to Container Registry
+      uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1
+      with:
+        username: ${{ secrets.REGISTRY_USER }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+        registry: ${{ env.IMAGE_REGISTRY }}
+
+    - name: Build Image
+      id: build-image
+      uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
+      with:
+        image: ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}
+        tags: ${{ env.PLATFORM_PAIR }}-${{ github.sha }}
+        context: bootc
+        containerfiles: |
+          bootc/Containerfile
+
+    - name: Push image by digest
+      id: push
+      run: |
+        buildah push --digestfile /tmp/digest \
+          ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}:${{ env.PLATFORM_PAIR }}-${{ github.sha }} \
+          docker://${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}:${{ env.PLATFORM_PAIR }}-${{ github.sha }}
+        echo "digest=$(cat /tmp/digest)" >> $GITHUB_OUTPUT
+
+    - name: Export digest
+      run: |
+        mkdir -p /tmp/digests
+        digest="${{ steps.push.outputs.digest }}"
+        touch "/tmp/digests/${digest#sha256:}"
+
+    - name: Upload digest
+      uses: actions/upload-artifact@ea0fc0168eb20b7b23e01ec26f1f02fa15e723a2 # v4.6.0
+      with:
+        name: digests-${{ env.PLATFORM_PAIR }}
+        path: /tmp/digests/*
+        if-no-files-found: error
+        retention-days: 1
+
+  merge:
+    name: Create multi-arch manifest and sign
+    outputs:
+      digest: ${{ steps.manifest_digest.outputs.digest }}
+      version: ${{ steps.parse_version.outputs.VERSION }}
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Install container tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y podman buildah skopeo
+
+    - name: Download digests
+      uses: actions/download-artifact@95815c38d39ff5e43e0dc3a3fb91f6aaa66f1e9b # v4.6.0
+      with:
+        path: /tmp/digests
+        pattern: digests-*
+        merge-multiple: true
+
+    - name: Parse version
+      id: parse_version
+      run: |
+        VERSION=${GITHUB_REF#refs/tags/v}
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+    - name: Log in to Container Registry
+      uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1
+      with:
+        username: ${{ secrets.REGISTRY_USER }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+        registry: ${{ env.IMAGE_REGISTRY }}
+
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Create and push manifest
+      run: |
+        IMAGE_URI="${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}"
+        VERSION="${{ steps.parse_version.outputs.VERSION }}"
+
+        # Create manifest list for each tag
+        for TAG in latest $VERSION ${{ github.sha }}; do
+          buildah manifest create ${IMAGE_URI}:${TAG}
+
+          # Add each architecture
+          for digest in /tmp/digests/*; do
+            digest_hash=$(basename $digest)
+            buildah manifest add ${IMAGE_URI}:${TAG} docker://${IMAGE_URI}@sha256:${digest_hash}
+          done
+
+          # Push the manifest
+          buildah manifest push --all ${IMAGE_URI}:${TAG} docker://${IMAGE_URI}:${TAG}
+        done
+
+    - name: Inspect manifest
+      run: |
+        IMAGE_URI="${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}"
+        buildah manifest inspect ${IMAGE_URI}:latest
+
+    - name: Install Cosign
+      if: ${{ env.COSIGN_PUBLIC_KEY != '' }}
+      uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+      with:
+        cosign-release: 'v2.2.4'
+
+    - name: Sign image recursively
+      if: ${{ env.COSIGN_PUBLIC_KEY != '' }}
+      env:
+        COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+      run: |
+        IMAGE_URI="${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}"
+        VERSION="${{ steps.parse_version.outputs.VERSION }}"
+
+        cosign sign --yes --recursive \
+          --registry-referrers-mode=legacy \
+          --key env://COSIGN_PRIVATE_KEY \
+          -a tag=$VERSION \
+          -a tag=latest \
+          -a sha=${{ github.sha }} \
+          -a run_id=${{ github.run_id }} \
+          -a run_attempt="$GITHUB_RUN_ATTEMPT" \
+          ${IMAGE_URI}:latest
+
+    - name: Verify image signature
+      if: ${{ env.COSIGN_PUBLIC_KEY != '' }}
+      run: |
+        IMAGE_URI="${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}"
+        echo "${{ env.COSIGN_PUBLIC_KEY }}" | base64 -d > /tmp/cosign.pub
+        cosign verify \
+          --key /tmp/cosign.pub \
+          ${IMAGE_URI}:latest
+        rm -f /tmp/cosign.pub
+
+    - name: Get manifest digest
+      id: manifest_digest
+      run: |
+        IMAGE_URI="${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}"
+        DIGEST=$(skopeo inspect --format '{{.Digest}}' docker://${IMAGE_URI}:latest)
+        echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+
+  attest:
+    name: Attest, scan, and generate SBOM
+    runs-on: ubuntu-latest
+    needs: merge
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      attestations: write
+      security-events: write
+
+    steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+      with:
+        egress-policy: audit
+
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+      with:
+        registry: ${{ env.IMAGE_REGISTRY }}
+        username: ${{ secrets.REGISTRY_USER }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+
+    - name: Generate SBOM
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      env:
+        SYFT_SELECT_CATALOGERS: "-file"
+        SYFT_FILE_METADATA_SELECTION: "none"
+      with:
+        image: ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}@${{ needs.merge.outputs.digest }}
+        format: cyclonedx-json
+        output-file: sbom.cdx.json
+
+    - name: Attest build provenance
+      uses: actions/attest-build-provenance@afb1fc95187626bc88bb3ae9e9c4d4c2d5f4e923 # v2.2.0
+      with:
+        subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}
+        subject-digest: ${{ needs.merge.outputs.digest }}
+        push-to-registry: true
+
+    - name: Attest SBOM
+      uses: actions/attest-sbom@b24a9c30925b5e3cc65a3f4a9a76ece1c6e97718 # v2.0.0
+      with:
+        subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}
+        subject-digest: ${{ needs.merge.outputs.digest }}
+        sbom-path: sbom.cdx.json
+        push-to-registry: true
+
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+      with:
+        image-ref: ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}@${{ needs.merge.outputs.digest }}
+        format: sarif
+        output: trivy-results.sarif
+        severity: CRITICAL,HIGH
+
+    - name: Upload Trivy results to GitHub Security
+      uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+      with:
+        sarif_file: trivy-results.sarif

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -36,7 +36,7 @@ jobs:
         echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
     - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Parse version
       id: parse_version
@@ -76,7 +76,7 @@ jobs:
         touch "/tmp/digests/${digest#sha256:}"
 
     - name: Upload digest
-      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: digests-${{ env.PLATFORM_PAIR }}
         path: /tmp/digests/*
@@ -100,7 +100,7 @@ jobs:
         sudo apt-get install -y podman buildah skopeo
 
     - name: Download digests
-      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: /tmp/digests
         pattern: digests-*
@@ -120,7 +120,7 @@ jobs:
         registry: ${{ env.IMAGE_REGISTRY }}
 
     - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Create and push manifest
       run: |
@@ -148,7 +148,7 @@ jobs:
 
     - name: Install Cosign
       if: ${{ env.COSIGN_PUBLIC_KEY != '' }}
-      uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       with:
         cosign-release: 'v2.2.4'
 
@@ -218,12 +218,12 @@ jobs:
 
     steps:
     - name: Harden runner
-      uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+      uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
       with:
         egress-policy: audit
 
     - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Log in to Container Registry
       uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
@@ -266,6 +266,6 @@ jobs:
         severity: CRITICAL,HIGH
 
     - name: Upload Trivy results to GitHub Security
-      uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+      uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
       with:
         sarif_file: trivy-results.sarif

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -179,7 +179,20 @@ jobs:
         cosign verify \
           --key /tmp/cosign.pub \
           ${IMAGE_URI}:latest
+
+    - name: Cleanup signing keys
+      if: always()
+      run: |
+        # Remove public key file if it exists
         rm -f /tmp/cosign.pub
+        # Clean up cosign cache/temp directories that might contain key material
+        rm -rf ~/.sigstore
+        rm -rf ~/.cosign
+        # Clear any cosign environment variables
+        unset COSIGN_PRIVATE_KEY
+        unset COSIGN_PASSWORD
+        # Overwrite memory (best effort on ephemeral runners)
+        sync
 
     - name: Get manifest digest
       id: manifest_digest

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -175,7 +175,7 @@ jobs:
       if: ${{ env.COSIGN_PUBLIC_KEY != '' }}
       run: |
         IMAGE_URI="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE }}"
-        echo "${{ env.COSIGN_PUBLIC_KEY }}" | base64 -d > /tmp/cosign.pub
+        echo "${{ env.COSIGN_PUBLIC_KEY }}" > /tmp/cosign.pub
         cosign verify \
           --key /tmp/cosign.pub \
           ${IMAGE_URI}:latest

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -76,7 +76,7 @@ jobs:
         touch "/tmp/digests/${digest#sha256:}"
 
     - name: Upload digest
-      uses: actions/upload-artifact@ea0fc0168eb20b7b23e01ec26f1f02fa15e723a2 # v4.6.0
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: digests-${{ env.PLATFORM_PAIR }}
         path: /tmp/digests/*
@@ -100,7 +100,7 @@ jobs:
         sudo apt-get install -y podman buildah skopeo
 
     - name: Download digests
-      uses: actions/download-artifact@95815c38d39ff5e43e0dc3a3fb91f6aaa66f1e9b # v4.6.0
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         path: /tmp/digests
         pattern: digests-*
@@ -243,14 +243,14 @@ jobs:
         output-file: sbom.cdx.json
 
     - name: Attest build provenance
-      uses: actions/attest-build-provenance@afb1fc95187626bc88bb3ae9e9c4d4c2d5f4e923 # v2.2.0
+      uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # v2.2.0
       with:
         subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE }}
         subject-digest: ${{ needs.merge.outputs.digest }}
         push-to-registry: true
 
     - name: Attest SBOM
-      uses: actions/attest-sbom@b24a9c30925b5e3cc65a3f4a9a76ece1c6e97718 # v2.0.0
+      uses: actions/attest-sbom@1455967b1b6415d3df9fac31a87500523f7b455c # v2.0.0
       with:
         subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE }}
         subject-digest: ${{ needs.merge.outputs.digest }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -6,8 +6,8 @@ on:
     - v*
 
 env:
-  REGISTRY_USER: ${{ vars.REGISTRY_USER }}
   IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY }}
+  IMAGE_NAMESPACE: ${{ vars.IMAGE_NAMESPACE }}
   IMAGE: tank-os
   COSIGN_PUBLIC_KEY: ${{ vars.COSIGN_PUBLIC_KEY }}
   RELEASE_REGISTRY: ${{ vars.RELEASE_REGISTRY }}
@@ -55,7 +55,7 @@ jobs:
       id: build-image
       uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
       with:
-        image: ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}
+        image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE }}
         tags: ${{ env.PLATFORM_PAIR }}-${{ github.sha }}
         context: bootc
         containerfiles: |
@@ -65,8 +65,8 @@ jobs:
       id: push
       run: |
         buildah push --digestfile /tmp/digest \
-          ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}:${{ env.PLATFORM_PAIR }}-${{ github.sha }} \
-          docker://${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}:${{ env.PLATFORM_PAIR }}-${{ github.sha }}
+          ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE }}:${{ env.PLATFORM_PAIR }}-${{ github.sha }} \
+          docker://${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE }}:${{ env.PLATFORM_PAIR }}-${{ github.sha }}
         echo "digest=$(cat /tmp/digest)" >> $GITHUB_OUTPUT
 
     - name: Export digest
@@ -124,7 +124,7 @@ jobs:
 
     - name: Create and push manifest
       run: |
-        IMAGE_URI="${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}"
+        IMAGE_URI="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE }}"
         VERSION="${{ steps.parse_version.outputs.VERSION }}"
 
         # Create manifest list for each tag
@@ -143,7 +143,7 @@ jobs:
 
     - name: Inspect manifest
       run: |
-        IMAGE_URI="${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}"
+        IMAGE_URI="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE }}"
         buildah manifest inspect ${IMAGE_URI}:latest
 
     - name: Install Cosign
@@ -158,7 +158,7 @@ jobs:
         COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
         COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
       run: |
-        IMAGE_URI="${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}"
+        IMAGE_URI="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE }}"
         VERSION="${{ steps.parse_version.outputs.VERSION }}"
 
         cosign sign --yes --recursive \
@@ -174,7 +174,7 @@ jobs:
     - name: Verify image signature
       if: ${{ env.COSIGN_PUBLIC_KEY != '' }}
       run: |
-        IMAGE_URI="${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}"
+        IMAGE_URI="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE }}"
         echo "${{ env.COSIGN_PUBLIC_KEY }}" | base64 -d > /tmp/cosign.pub
         cosign verify \
           --key /tmp/cosign.pub \
@@ -197,7 +197,7 @@ jobs:
     - name: Get manifest digest
       id: manifest_digest
       run: |
-        IMAGE_URI="${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}"
+        IMAGE_URI="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE }}"
         DIGEST=$(skopeo inspect --format '{{.Digest}}' docker://${IMAGE_URI}:latest)
         echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
@@ -205,6 +205,10 @@ jobs:
     name: Attest, scan, and generate SBOM
     runs-on: ubuntu-latest
     needs: merge
+    env:
+      IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY }}
+      IMAGE_NAMESPACE: ${{ vars.IMAGE_NAMESPACE }}
+      IMAGE: tank-os
     permissions:
       contents: write
       packages: write
@@ -234,21 +238,21 @@ jobs:
         SYFT_SELECT_CATALOGERS: "-file"
         SYFT_FILE_METADATA_SELECTION: "none"
       with:
-        image: ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}@${{ needs.merge.outputs.digest }}
+        image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE }}@${{ needs.merge.outputs.digest }}
         format: cyclonedx-json
         output-file: sbom.cdx.json
 
     - name: Attest build provenance
       uses: actions/attest-build-provenance@afb1fc95187626bc88bb3ae9e9c4d4c2d5f4e923 # v2.2.0
       with:
-        subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}
+        subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE }}
         subject-digest: ${{ needs.merge.outputs.digest }}
         push-to-registry: true
 
     - name: Attest SBOM
       uses: actions/attest-sbom@b24a9c30925b5e3cc65a3f4a9a76ece1c6e97718 # v2.0.0
       with:
-        subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}
+        subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE }}
         subject-digest: ${{ needs.merge.outputs.digest }}
         sbom-path: sbom.cdx.json
         push-to-registry: true
@@ -256,7 +260,7 @@ jobs:
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       with:
-        image-ref: ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}@${{ needs.merge.outputs.digest }}
+        image-ref: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE }}@${{ needs.merge.outputs.digest }}
         format: sarif
         output: trivy-results.sarif
         severity: CRITICAL,HIGH

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -146,14 +146,26 @@ jobs:
         IMAGE_URI="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE }}"
         buildah manifest inspect ${IMAGE_URI}:latest
 
+    - name: Check signing secrets
+      id: check_signing
+      env:
+        COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+      run: |
+        if [ -n "$COSIGN_PRIVATE_KEY" ] && [ -n "$COSIGN_PASSWORD" ]; then
+          echo "available=true" >> $GITHUB_OUTPUT
+        else
+          echo "available=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Install Cosign
-      if: ${{ env.COSIGN_PUBLIC_KEY != '' }}
+      if: ${{ env.COSIGN_PUBLIC_KEY != '' && steps.check_signing.outputs.available == 'true' }}
       uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       with:
         cosign-release: 'v2.2.4'
 
     - name: Sign image recursively
-      if: ${{ env.COSIGN_PUBLIC_KEY != '' }}
+      if: ${{ env.COSIGN_PUBLIC_KEY != '' && steps.check_signing.outputs.available == 'true' }}
       env:
         COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
         COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
@@ -172,7 +184,7 @@ jobs:
           ${IMAGE_URI}:latest
 
     - name: Verify image signature
-      if: ${{ env.COSIGN_PUBLIC_KEY != '' }}
+      if: ${{ env.COSIGN_PUBLIC_KEY != '' && steps.check_signing.outputs.available == 'true' }}
       run: |
         IMAGE_URI="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE }}"
         echo "${{ env.COSIGN_PUBLIC_KEY }}" > /tmp/cosign.pub
@@ -181,7 +193,7 @@ jobs:
           ${IMAGE_URI}:latest
 
     - name: Cleanup signing keys
-      if: always()
+      if: ${{ always() && steps.check_signing.outputs.available == 'true' }}
       run: |
         # Remove public key file if it exists
         rm -f /tmp/cosign.pub

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -37,6 +37,8 @@ jobs:
 
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Parse version
       id: parse_version
@@ -118,9 +120,6 @@ jobs:
         username: ${{ secrets.REGISTRY_USER }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
         registry: ${{ env.IMAGE_REGISTRY }}
-
-    - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Create and push manifest
       run: |
@@ -236,6 +235,8 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Log in to Container Registry
       uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,37 @@
+name: Lint PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  lint:
+    permissions:
+      contents: read
+    if: ${{ github.head_ref != 'main' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+      with:
+        egress-policy: audit
+
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+
+    - name: Install dependencies
+      run: npm install @commitlint/cli @commitlint/config-conventional
+
+    - name: Validate PR title
+      run: |
+        PR_TITLE=$(jq -r '.pull_request.title' "$GITHUB_EVENT_PATH")
+        echo "$PR_TITLE" | npx commitlint --config commitlint.config.js

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -23,10 +23,10 @@ jobs:
       with:
         egress-policy: audit
 
-    - name: Checkout code
+    - name: Checkout PR branch
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        ref: ${{ github.event.pull_request.base.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Install dependencies
       run: npm install @commitlint/cli @commitlint/config-conventional

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Harden runner
-      uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+      uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
       with:
         egress-policy: audit
 
     - name: Checkout PR branch
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -23,10 +23,11 @@ jobs:
       with:
         egress-policy: audit
 
-    - name: Checkout PR branch
+    - name: Checkout base branch
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event.pull_request.base.sha }}
+        persist-credentials: false
 
     - name: Install dependencies
       run: npm install @commitlint/cli @commitlint/config-conventional

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,7 +28,7 @@ jobs:
         echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
     - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Build Image
       id: build-image
@@ -52,7 +52,7 @@ jobs:
 
     steps:
     - name: Harden runner
-      uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+      uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
       with:
         egress-policy: audit
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,11 +5,6 @@ on:
     branches:
       - main
 
-env:
-  REGISTRY_USER: ${{ vars.REGISTRY_USER }}
-  IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY }}
-  IMAGE: tank-os
-
 permissions: read-all
 
 jobs:
@@ -39,7 +34,7 @@ jobs:
       id: build-image
       uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
       with:
-        image: ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}
+        image: localhost/tank-os
         tags: ${{ env.PLATFORM_PAIR }}-${{ github.sha }}
         context: bootc
         containerfiles: |
@@ -47,7 +42,7 @@ jobs:
 
     - name: Validate image
       run: |
-        buildah inspect ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}:${{ env.PLATFORM_PAIR }}-${{ github.sha }}
+        buildah inspect localhost/tank-os:${{ env.PLATFORM_PAIR }}-${{ github.sha }}
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,73 @@
+name: Validate Build and Create Release
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  REGISTRY_USER: ${{ vars.REGISTRY_USER }}
+  IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY }}
+  IMAGE: tank-os
+
+permissions: read-all
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    steps:
+    - name: Prepare platform pair
+      run: |
+        platform=${{ matrix.platform }}
+        echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Build Image
+      id: build-image
+      uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
+      with:
+        image: ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}
+        tags: ${{ env.PLATFORM_PAIR }}-${{ github.sha }}
+        context: bootc
+        containerfiles: |
+          bootc/Containerfile
+
+    - name: Validate image
+      run: |
+        buildah inspect ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}:${{ env.PLATFORM_PAIR }}-${{ github.sha }}
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+
+    steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.FG_PAT }}
+
+    - name: Python Semantic Release
+      id: release
+      uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
+      with:
+        github_token: ${{ secrets.FG_PAT }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -29,6 +29,8 @@ jobs:
 
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Build Image
       id: build-image

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,7 +28,7 @@ jobs:
         echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
     - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Build Image
       id: build-image

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,50 @@
+name: PR Build Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: read-all
+
+env:
+  REGISTRY_USER: ${{ vars.REGISTRY_USER }}
+  IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY }}
+  IMAGE: tank-os
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    steps:
+    - name: Prepare platform pair
+      run: |
+        platform=${{ matrix.platform }}
+        echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Build Image
+      id: build-image
+      uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
+      with:
+        image: ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}
+        tags: ${{ env.PLATFORM_PAIR }}-${{ github.sha }}
+        context: bootc
+        containerfiles: |
+          bootc/Containerfile
+
+    - name: Validate image
+      run: |
+        buildah inspect ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}:${{ env.PLATFORM_PAIR }}-${{ github.sha }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,11 +7,6 @@ on:
 
 permissions: read-all
 
-env:
-  REGISTRY_USER: ${{ vars.REGISTRY_USER }}
-  IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY }}
-  IMAGE: tank-os
-
 jobs:
   build:
     name: Build ${{ matrix.platform }}
@@ -39,7 +34,7 @@ jobs:
       id: build-image
       uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
       with:
-        image: ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}
+        image: localhost/tank-os
         tags: ${{ env.PLATFORM_PAIR }}-${{ github.sha }}
         context: bootc
         containerfiles: |
@@ -47,4 +42,4 @@ jobs:
 
     - name: Validate image
       run: |
-        buildah inspect ${{ env.IMAGE_REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE }}:${{ env.PLATFORM_PAIR }}-${{ github.sha }}
+        buildah inspect localhost/tank-os:${{ env.PLATFORM_PAIR }}-${{ github.sha }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -29,6 +29,8 @@ jobs:
 
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Build Image
       id: build-image

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,41 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Monday at 06:00 UTC
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+      with:
+        egress-policy: audit
+
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
+
+    - name: Run Scorecard
+      uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+      with:
+        results_file: results.sarif
+        results_format: sarif
+        publish_results: true
+
+    - name: Upload SARIF results
+      uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+      with:
+        sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
     - name: Harden runner
-      uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+      uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
       with:
         egress-policy: audit
 
     - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 
@@ -36,6 +36,6 @@ jobs:
         publish_results: true
 
     - name: Upload SARIF results
-      uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+      uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
       with:
         sarif_file: results.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 *.img
 *.zst
 /.tmp/
-out-tank-os/
+/out-tank-os/
 .playwright-mcp/
+prompt.md

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /out-tank-os/
 .playwright-mcp/
 prompt.md
+cosign.key
+cosign.pub

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,138 @@
+# tank-os Makefile
+
+# Registry configuration (no defaults - must be set explicitly)
+IMAGE_REGISTRY ?=
+REGISTRY_USER ?=
+IMAGE := tank-os
+
+# Auto-detect architecture
+UNAME_ARCH := $(shell uname -m)
+ifeq ($(UNAME_ARCH),x86_64)
+	ARCH := amd64
+else ifeq ($(UNAME_ARCH),aarch64)
+	ARCH := arm64
+else ifeq ($(UNAME_ARCH),arm64)
+	ARCH := arm64
+else
+	ARCH := $(UNAME_ARCH)
+endif
+
+# Image URI construction
+ifneq ($(IMAGE_REGISTRY),)
+  ifneq ($(REGISTRY_USER),)
+    IMAGE_URI := $(IMAGE_REGISTRY)/$(REGISTRY_USER)/$(IMAGE)
+  else
+    IMAGE_URI := localhost/$(IMAGE)
+  endif
+else
+  IMAGE_URI := localhost/$(IMAGE)
+endif
+
+PLATFORM := linux/$(ARCH)
+
+.PHONY: help
+help:
+	@echo "tank-os Makefile"
+	@echo ""
+	@echo "Common targets:"
+	@echo "  build          Build the bootc container image locally"
+	@echo "  push           Push the image to registry (requires IMAGE_REGISTRY and REGISTRY_USER)"
+	@echo "  build-qcow2    Build a QCOW2 disk image using bootc-image-builder"
+	@echo "  build-iso      Build an ISO installer using bootc-image-builder"
+	@echo "  lint           Run bootc container lint (if available)"
+	@echo "  verify         Verify image signature with cosign (if COSIGN_PUBLIC_KEY is set)"
+	@echo "  clean          Remove build artifacts"
+	@echo ""
+	@echo "Current configuration:"
+	@echo "  ARCH:           $(ARCH)"
+	@echo "  PLATFORM:       $(PLATFORM)"
+	@echo "  IMAGE_URI:      $(IMAGE_URI)"
+	@echo "  IMAGE_REGISTRY: $(IMAGE_REGISTRY)"
+	@echo "  REGISTRY_USER:  $(REGISTRY_USER)"
+
+.PHONY: build
+build:
+	podman build --platform $(PLATFORM) -t $(IMAGE_URI):latest -f bootc/Containerfile bootc
+
+.PHONY: push
+push:
+	@if [ -z "$(IMAGE_REGISTRY)" ] || [ -z "$(REGISTRY_USER)" ]; then \
+		echo "Error: IMAGE_REGISTRY and REGISTRY_USER must be set to push images"; \
+		echo "Example: make push IMAGE_REGISTRY=quay.io REGISTRY_USER=myuser"; \
+		exit 1; \
+	fi
+	podman push $(IMAGE_URI):latest
+
+.PHONY: build-qcow2
+build-qcow2:
+	@if [ ! -f "config.toml" ]; then \
+		echo "Error: config.toml not found. Create one in the repo root for bootc-image-builder."; \
+		echo "See docs/build.md for examples."; \
+		exit 1; \
+	fi
+	mkdir -p out-tank-os
+	podman run --rm --privileged \
+		--security-opt label=type:unconfined_t \
+		-v ./out-tank-os:/output \
+		-v ./config.toml:/config.toml:ro \
+		-v /var/lib/containers/storage:/var/lib/containers/storage \
+		quay.io/centos-bootc/bootc-image-builder:latest \
+		$(IMAGE_URI):latest \
+		--output /output/ \
+		--local \
+		--type qcow2 \
+		--target-arch $(ARCH) \
+		--rootfs xfs \
+		--config /config.toml
+
+.PHONY: build-iso
+build-iso:
+	@if [ ! -f "config.toml" ]; then \
+		echo "Error: config.toml not found. Create one in the repo root for bootc-image-builder."; \
+		echo "See docs/build.md for examples."; \
+		exit 1; \
+	fi
+	mkdir -p out-tank-os
+	podman run --rm --privileged \
+		--security-opt label=type:unconfined_t \
+		-v ./out-tank-os:/output \
+		-v ./config.toml:/config.toml:ro \
+		-v /var/lib/containers/storage:/var/lib/containers/storage \
+		quay.io/centos-bootc/bootc-image-builder:latest \
+		$(IMAGE_URI):latest \
+		--output /output/ \
+		--local \
+		--type anaconda-iso \
+		--target-arch $(ARCH) \
+		--rootfs xfs \
+		--config /config.toml
+
+.PHONY: lint
+lint:
+	@if command -v bootc >/dev/null 2>&1; then \
+		podman run --rm $(IMAGE_URI):latest bootc container lint; \
+	else \
+		echo "bootc command not found, skipping lint"; \
+	fi
+
+.PHONY: verify
+verify:
+	@if [ -z "$(COSIGN_PUBLIC_KEY)" ]; then \
+		echo "COSIGN_PUBLIC_KEY not set, skipping verification"; \
+		exit 0; \
+	fi
+	@if [ -z "$(IMAGE_REGISTRY)" ] || [ -z "$(REGISTRY_USER)" ]; then \
+		echo "Error: IMAGE_REGISTRY and REGISTRY_USER must be set to verify images"; \
+		exit 1; \
+	fi
+	@if ! command -v cosign >/dev/null 2>&1; then \
+		echo "Error: cosign command not found"; \
+		exit 1; \
+	fi
+	echo "$$COSIGN_PUBLIC_KEY" | base64 -d > /tmp/cosign.pub
+	cosign verify --key /tmp/cosign.pub $(IMAGE_URI):latest
+	rm -f /tmp/cosign.pub
+
+.PHONY: clean
+clean:
+	rm -rf out-tank-os

--- a/Makefile
+++ b/Makefile
@@ -129,9 +129,9 @@ verify:
 		echo "Error: cosign command not found"; \
 		exit 1; \
 	fi
-	echo "$$COSIGN_PUBLIC_KEY" | base64 -d > /tmp/cosign.pub
+	@trap 'rm -f /tmp/cosign.pub' EXIT; \
+	echo "$$COSIGN_PUBLIC_KEY" | base64 -d > /tmp/cosign.pub && \
 	cosign verify --key /tmp/cosign.pub $(IMAGE_URI):latest
-	rm -f /tmp/cosign.pub
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Registry configuration (no defaults - must be set explicitly)
 IMAGE_REGISTRY ?=
-REGISTRY_USER ?=
+IMAGE_NAMESPACE ?=
 IMAGE := tank-os
 
 # Auto-detect architecture
@@ -19,8 +19,8 @@ endif
 
 # Image URI construction
 ifneq ($(IMAGE_REGISTRY),)
-  ifneq ($(REGISTRY_USER),)
-    IMAGE_URI := $(IMAGE_REGISTRY)/$(REGISTRY_USER)/$(IMAGE)
+  ifneq ($(IMAGE_NAMESPACE),)
+    IMAGE_URI := $(IMAGE_REGISTRY)/$(IMAGE_NAMESPACE)/$(IMAGE)
   else
     IMAGE_URI := localhost/$(IMAGE)
   endif
@@ -36,7 +36,7 @@ help:
 	@echo ""
 	@echo "Common targets:"
 	@echo "  build          Build the bootc container image locally"
-	@echo "  push           Push the image to registry (requires IMAGE_REGISTRY and REGISTRY_USER)"
+	@echo "  push           Push the image to registry (requires IMAGE_REGISTRY and IMAGE_NAMESPACE)"
 	@echo "  build-qcow2    Build a QCOW2 disk image using bootc-image-builder"
 	@echo "  build-iso      Build an ISO installer using bootc-image-builder"
 	@echo "  lint           Run bootc container lint (if available)"
@@ -44,11 +44,11 @@ help:
 	@echo "  clean          Remove build artifacts"
 	@echo ""
 	@echo "Current configuration:"
-	@echo "  ARCH:           $(ARCH)"
-	@echo "  PLATFORM:       $(PLATFORM)"
-	@echo "  IMAGE_URI:      $(IMAGE_URI)"
-	@echo "  IMAGE_REGISTRY: $(IMAGE_REGISTRY)"
-	@echo "  REGISTRY_USER:  $(REGISTRY_USER)"
+	@echo "  ARCH:            $(ARCH)"
+	@echo "  PLATFORM:        $(PLATFORM)"
+	@echo "  IMAGE_URI:       $(IMAGE_URI)"
+	@echo "  IMAGE_REGISTRY:  $(IMAGE_REGISTRY)"
+	@echo "  IMAGE_NAMESPACE: $(IMAGE_NAMESPACE)"
 
 .PHONY: build
 build:
@@ -56,9 +56,9 @@ build:
 
 .PHONY: push
 push:
-	@if [ -z "$(IMAGE_REGISTRY)" ] || [ -z "$(REGISTRY_USER)" ]; then \
-		echo "Error: IMAGE_REGISTRY and REGISTRY_USER must be set to push images"; \
-		echo "Example: make push IMAGE_REGISTRY=quay.io REGISTRY_USER=myuser"; \
+	@if [ -z "$(IMAGE_REGISTRY)" ] || [ -z "$(IMAGE_NAMESPACE)" ]; then \
+		echo "Error: IMAGE_REGISTRY and IMAGE_NAMESPACE must be set to push images"; \
+		echo "Example: make push IMAGE_REGISTRY=quay.io IMAGE_NAMESPACE=myorg"; \
 		exit 1; \
 	fi
 	podman push $(IMAGE_URI):latest
@@ -121,8 +121,8 @@ verify:
 		echo "COSIGN_PUBLIC_KEY not set, skipping verification"; \
 		exit 0; \
 	fi
-	@if [ -z "$(IMAGE_REGISTRY)" ] || [ -z "$(REGISTRY_USER)" ]; then \
-		echo "Error: IMAGE_REGISTRY and REGISTRY_USER must be set to verify images"; \
+	@if [ -z "$(IMAGE_REGISTRY)" ] || [ -z "$(IMAGE_NAMESPACE)" ]; then \
+		echo "Error: IMAGE_REGISTRY and IMAGE_NAMESPACE must be set to verify images"; \
 		exit 1; \
 	fi
 	@if ! command -v cosign >/dev/null 2>&1; then \

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ verify:
 		exit 1; \
 	fi
 	@trap 'rm -f /tmp/cosign.pub' EXIT; \
-	echo "$$COSIGN_PUBLIC_KEY" | base64 -d > /tmp/cosign.pub && \
+	printf '%s\n' "$$COSIGN_PUBLIC_KEY" > /tmp/cosign.pub && \
 	cosign verify --key /tmp/cosign.pub $(IMAGE_URI):latest
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -109,10 +109,10 @@ build-iso:
 
 .PHONY: lint
 lint:
-	@if command -v bootc >/dev/null 2>&1; then \
+	@if command -v podman >/dev/null 2>&1; then \
 		podman run --rm $(IMAGE_URI):latest bootc container lint; \
 	else \
-		echo "bootc command not found, skipping lint"; \
+		echo "podman command not found, skipping lint"; \
 	fi
 
 .PHONY: verify

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'subject-case': [2, 'never', ['start-case', 'pascal-case', 'upper-case']],
+  },
+};

--- a/docs/build.md
+++ b/docs/build.md
@@ -280,6 +280,12 @@ If these are not set, the signing steps are gracefully skipped. Generate a cosig
 cosign generate-key-pair
 ```
 
+**Security Note**: The CI/CD pipeline includes automatic cleanup of signing keys:
+- A dedicated cleanup step always runs (even if signing fails) to remove temporary key files
+- Cosign cache directories (`~/.sigstore`, `~/.cosign`) are purged after signing
+- The Makefile's `verify` target uses a trap to ensure public key cleanup on exit
+- Private keys are never written to disk (passed via environment variables only)
+
 ### Optional: Release Registry Pinning
 
 Set the `RELEASE_REGISTRY` variable to the full registry/repo path that deployed images should trust for updates:

--- a/docs/build.md
+++ b/docs/build.md
@@ -209,7 +209,7 @@ make build-qcow2
 make build-iso
 
 # Verify image signature (if COSIGN_PUBLIC_KEY env var is set)
-make verify COSIGN_PUBLIC_KEY="$(cat cosign.pub | base64)" \
+make verify COSIGN_PUBLIC_KEY="$(cat cosign.pub)" \
   IMAGE_REGISTRY=quay.io IMAGE_NAMESPACE=myorg
 
 # Clean build artifacts
@@ -298,16 +298,21 @@ And these **repository secrets** (Settings → Secrets and variables → Actions
 To enable image signing with cosign:
 
 **Repository variables:**
-- `COSIGN_PUBLIC_KEY` — base64-encoded cosign public key (output of `cat cosign.pub | base64`)
+- `COSIGN_PUBLIC_KEY` — cosign public key content (PEM format, multi-line)
+  - Paste the entire content of `cosign.pub` directly into the variable
+  - Include the `-----BEGIN PUBLIC KEY-----` and `-----END PUBLIC KEY-----` lines
+  - GitHub variables handle multi-line content correctly
 
 **Repository secrets:**
-- `COSIGN_PRIVATE_KEY` — cosign private key
+- `COSIGN_PRIVATE_KEY` — cosign private key (full PEM content)
 - `COSIGN_PASSWORD` — passphrase for the cosign key
 
 If these are not set, the signing steps are gracefully skipped. Generate a cosign keypair:
 
 ```bash
 cosign generate-key-pair
+# Then copy the contents of cosign.pub (entire file) to COSIGN_PUBLIC_KEY variable
+# And copy the contents of cosign.key (entire file) to COSIGN_PRIVATE_KEY secret
 ```
 
 **Security Note**: The CI/CD pipeline includes automatic cleanup of signing keys:

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,5 +1,19 @@
 # Build
 
+## Quick Start with Makefile
+
+The easiest way to build locally is using `make`:
+
+```bash
+# Build the image (auto-detects architecture)
+make build
+
+# View all available targets
+make help
+```
+
+See **Makefile Targets** below for details.
+
 ## Build The Bootc Container Image
 
 Skip this section if you want to build a disk image directly from the published
@@ -176,3 +190,123 @@ After the reboot, future updates against the same tracked tag can use:
 ```bash
 sudo bootc upgrade --apply
 ```
+
+## Makefile Targets
+
+The `Makefile` provides convenient local build commands:
+
+```bash
+# Build the image locally (auto-detects architecture)
+make build
+
+# Build and push to a registry (requires IMAGE_REGISTRY and REGISTRY_USER)
+make build push IMAGE_REGISTRY=quay.io REGISTRY_USER=myuser
+
+# Build a QCOW2 disk image (requires config.toml in repo root)
+make build-qcow2
+
+# Build an ISO installer (requires config.toml in repo root)
+make build-iso
+
+# Verify image signature (if COSIGN_PUBLIC_KEY env var is set)
+make verify COSIGN_PUBLIC_KEY="$(cat cosign.pub | base64)"
+
+# Clean build artifacts
+make clean
+```
+
+The Makefile automatically detects your architecture (`arm64` or `amd64`) and builds for that platform. Images are tagged as `localhost/tank-os:latest` by default, or `<REGISTRY>/<USER>/tank-os:latest` if registry variables are set.
+
+## CI/CD System
+
+The repository includes a full GitHub Actions CI/CD pipeline adapted from enterprise bootc image build patterns.
+
+### Workflows
+
+1. **PR validation** (`.github/workflows/pr.yaml`)
+   - Triggers on pull requests to `main`
+   - Builds images for both `amd64` and `arm64` architectures
+   - Validates images with `buildah inspect`
+   - No images are pushed
+
+2. **Semantic release** (`.github/workflows/create-release.yml`)
+   - Triggers on push to `main` (merged PRs)
+   - Validates the build on both architectures
+   - Creates a semantic version tag (e.g., `v1.2.3`) using `python-semantic-release`
+
+3. **Full release** (`.github/workflows/build-release.yml`)
+   - Triggers on version tags (`v*`)
+   - Builds per-architecture images and pushes them by digest
+   - Creates multi-arch manifest lists with tags: `latest`, `<VERSION>`, `<SHA>`
+   - **Conditionally** signs images with cosign (if `COSIGN_PRIVATE_KEY` secret is set)
+   - Generates SBOM (Software Bill of Materials)
+   - Creates build provenance and SBOM attestations
+   - Runs Trivy vulnerability scanner and uploads results to GitHub Security
+
+4. **PR title linting** (`.github/workflows/commitlint.yml`)
+   - Validates PR titles follow conventional commit format
+
+5. **OpenSSF Scorecard** (`.github/workflows/scorecard.yml`)
+   - Weekly security analysis via OpenSSF Scorecard
+
+### Fork Setup: Required Configuration
+
+To use the CI/CD system in a fork, configure these **repository variables** (Settings → Secrets and variables → Actions → Variables):
+
+- `REGISTRY_USER` — your registry username (e.g., `myuser`) **[required]**
+- `IMAGE_REGISTRY` — registry hostname (e.g., `quay.io` or `ghcr.io`) **[required]**
+
+And these **repository secrets** (Settings → Secrets and variables → Actions → Secrets):
+
+- `REGISTRY_PASSWORD` — registry password or token **[required]**
+- `FG_PAT` — fine-grained GitHub Personal Access Token for creating release tags **[required]**
+  - Token needs `contents: write` permission on the repository
+  - Create at: https://github.com/settings/personal-access-tokens/new
+
+### Fork Setup: Optional Configuration (Image Signing)
+
+To enable image signing with cosign:
+
+**Repository variables:**
+- `COSIGN_PUBLIC_KEY` — base64-encoded cosign public key (output of `cat cosign.pub | base64`)
+
+**Repository secrets:**
+- `COSIGN_PRIVATE_KEY` — cosign private key
+- `COSIGN_PASSWORD` — passphrase for the cosign key
+
+If these are not set, the signing steps are gracefully skipped. Generate a cosign keypair:
+
+```bash
+cosign generate-key-pair
+```
+
+### Optional: Release Registry Pinning
+
+Set the `RELEASE_REGISTRY` variable to the full registry/repo path that deployed images should trust for updates:
+
+- `RELEASE_REGISTRY` — e.g., `quay.io/myorg/tank-os`
+
+This is used for container signature policy configuration if you implement supply chain verification.
+
+### First-time Setup
+
+After setting the required variables and secrets:
+
+1. Merge a PR to `main` → triggers `create-release.yml` which creates the first tag (e.g., `v0.1.0`)
+2. Tag push triggers `build-release.yml` → multi-arch image is built, signed (if configured), and pushed to your registry
+
+### Semantic Versioning
+
+The pipeline uses `python-semantic-release` to automatically determine version bumps based on commit messages:
+
+- `feat:` prefix → minor version bump (e.g., `v1.2.0` → `v1.3.0`)
+- `fix:` prefix → patch version bump (e.g., `v1.2.0` → `v1.2.1`)
+- `BREAKING CHANGE:` in commit body → major version bump (e.g., `v1.2.0` → `v2.0.0`)
+
+PR titles are validated to follow conventional commit format via commitlint.
+
+### Dependabot
+
+The repository includes Dependabot configuration (`.github/dependabot.yml`) for automated updates:
+- GitHub Actions (weekly)
+- Docker base images (weekly)

--- a/docs/build.md
+++ b/docs/build.md
@@ -199,8 +199,8 @@ The `Makefile` provides convenient local build commands:
 # Build the image locally (auto-detects architecture)
 make build
 
-# Build and push to a registry (requires IMAGE_REGISTRY and REGISTRY_USER)
-make build push IMAGE_REGISTRY=quay.io REGISTRY_USER=myuser
+# Build and push to a registry (requires IMAGE_REGISTRY and IMAGE_NAMESPACE)
+make build push IMAGE_REGISTRY=quay.io IMAGE_NAMESPACE=myorg
 
 # Build a QCOW2 disk image (requires config.toml in repo root)
 make build-qcow2
@@ -209,13 +209,16 @@ make build-qcow2
 make build-iso
 
 # Verify image signature (if COSIGN_PUBLIC_KEY env var is set)
-make verify COSIGN_PUBLIC_KEY="$(cat cosign.pub | base64)"
+make verify COSIGN_PUBLIC_KEY="$(cat cosign.pub | base64)" \
+  IMAGE_REGISTRY=quay.io IMAGE_NAMESPACE=myorg
 
 # Clean build artifacts
 make clean
 ```
 
-The Makefile automatically detects your architecture (`arm64` or `amd64`) and builds for that platform. Images are tagged as `localhost/tank-os:latest` by default, or `<REGISTRY>/<USER>/tank-os:latest` if registry variables are set.
+The Makefile automatically detects your architecture (`arm64` or `amd64`) and builds for that platform. Images are tagged as `localhost/tank-os:latest` by default, or `<REGISTRY>/<NAMESPACE>/tank-os:latest` if registry variables are set.
+
+**Note**: The Makefile uses `IMAGE_NAMESPACE` for the image path. Authentication credentials are handled separately via `podman login` before running `make push`.
 
 ## CI/CD System
 
@@ -253,15 +256,42 @@ The repository includes a full GitHub Actions CI/CD pipeline adapted from enterp
 
 To use the CI/CD system in a fork, configure these **repository variables** (Settings → Secrets and variables → Actions → Variables):
 
-- `REGISTRY_USER` — your registry username (e.g., `myuser`) **[required]**
 - `IMAGE_REGISTRY` — registry hostname (e.g., `quay.io` or `ghcr.io`) **[required]**
+- `IMAGE_NAMESPACE` — organization or user namespace in the registry (e.g., `myorg` or `myuser`) **[required]**
+  - This is the path component after the registry: `quay.io/{IMAGE_NAMESPACE}/tank-os`
+  - Examples: `myorg`, `myuser`, `my-team`
 
 And these **repository secrets** (Settings → Secrets and variables → Actions → Secrets):
 
+- `REGISTRY_USER` — username for authentication to the registry **[required]**
+  - This is used for `podman login` / `docker login` authentication only
+  - May be different from `IMAGE_NAMESPACE` (e.g., robot account or service account)
 - `REGISTRY_PASSWORD` — registry password or token **[required]**
 - `FG_PAT` — fine-grained GitHub Personal Access Token for creating release tags **[required]**
   - Token needs `contents: write` permission on the repository
   - Create at: https://github.com/settings/personal-access-tokens/new
+
+**Example Configuration**:
+- **Scenario 1**: Personal account pushing to personal namespace
+  - `IMAGE_REGISTRY`: `quay.io`
+  - `IMAGE_NAMESPACE`: `myuser`
+  - `REGISTRY_USER`: `myuser` (secret)
+  - `REGISTRY_PASSWORD`: `mypassword` (secret)
+  - **Result**: Images pushed to `quay.io/myuser/tank-os`
+
+- **Scenario 2**: Robot account pushing to organization namespace
+  - `IMAGE_REGISTRY`: `quay.io`
+  - `IMAGE_NAMESPACE`: `myorg`
+  - `REGISTRY_USER`: `myorg+robot` (secret)
+  - `REGISTRY_PASSWORD`: `robot-token` (secret)
+  - **Result**: Images pushed to `quay.io/myorg/tank-os`
+
+- **Scenario 3**: GitHub GHCR with personal account pushing to org
+  - `IMAGE_REGISTRY`: `ghcr.io`
+  - `IMAGE_NAMESPACE`: `myorg`
+  - `REGISTRY_USER`: `myuser` (secret)
+  - `REGISTRY_PASSWORD`: `ghp_...` (secret - GitHub PAT)
+  - **Result**: Images pushed to `ghcr.io/myorg/tank-os`
 
 ### Fork Setup: Optional Configuration (Image Signing)
 


### PR DESCRIPTION
## Summary

This PR adds a complete GitHub Actions CI/CD pipeline for tank-os with multi-architecture builds, image signing, SBOM generation, and security scanning.

This complements the existing open PR #1 (nightly build workflow) by @cooktheryan. That PR focuses on nightly/push builds, while this PR provides:
- **Release-based workflow** (triggered on git tags)
- **Image signing** with cosign (optional, configurable)
- **SBOM generation** and attestation
- **Build provenance** attestation
- **Security scanning** with Trivy
- **Conventional commit enforcement** (commitlint)
- **OpenSSF Scorecard** security analysis
- **PR validation builds** (multi-arch, no push)

Both workflows can coexist, or maintainers can choose one approach. The workflows are fully parameterized via repository variables and secrets for easy configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Makefile to build, push, produce QCOW2/ISO images, verify signatures, and related convenience targets.

* **CI/CD**
  * Workflows for PR build validation, release creation, multi-arch image build/publish with optional signing and SBOM/attestation, commit-title linting, and automated security scans with SARIF upload.

* **Documentation**
  * Expanded build docs with Makefile quick start, targets, CI/CD and release guidance.

* **Chores**
  * Dependabot scheduled updates configured; .gitignore updated to exclude build artifacts and signing keys.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LobsterTrap/tank-os/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->