### PR TITLE
fix: Add support for OPENCLAW_GATEWAY_TOKEN

### DIFF
--- a/bootc/rootfs/usr/libexec/tank-os/sync-podman-secrets
+++ b/bootc/rootfs/usr/libexec/tank-os/sync-podman-secrets
@@ -34,6 +34,7 @@ add_openclaw_secret "google_api_key" "GOOGLE_API_KEY"
 add_openclaw_secret "openrouter_api_key" "OPENROUTER_API_KEY"
 add_openclaw_secret "model_endpoint_api_key" "MODEL_ENDPOINT_API_KEY"
 add_openclaw_secret "telegram_bot_token" "TELEGRAM_BOT_TOKEN"
+add_openclaw_secret "openclaw_gateway_token" "OPENCLAW_GATEWAY_TOKEN"
 
 {
   printf '[Container]\n'

--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -25,6 +25,8 @@ runcmd:
 
 After boot:
 
+`ssh openclaw@<host>` and [configure the Gateway token.](provisioning.md#gateway-token-setup)
+
 ```bash
 ssh openclaw@<host>
 cd ~/.openclaw
@@ -222,7 +224,24 @@ systemctl --user restart openclaw.service
 
 ## Podman Secrets
 
-Create Podman secrets in the `openclaw` user's rootless store:
+Create Podman secrets in the `openclaw` user's rootless store and inject them into the OpenClaw container.
+
+### Gateway Token Setup
+
+Execute the following commands to create the Openclaw Gateway Token:
+
+```bash
+sudo -iu openclaw
+printf '%s' "$OPENCLAW_GATEWAY_TOKEN" | podman secret create openclaw_gateway_token -
+tank-openclaw-secrets
+systemctl --user restart openclaw.service
+```
+
+The `openclaw_gateway_token` Podman secret is injected into the OpenClaw container as `OPENCLAW_GATEWAY_TOKEN`, which satisfies gateway token auth without storing the token in `openclaw.json`.
+
+### API Key Setup
+
+Execute the following commands to create secrets for Anthropic and OpenAI keys:
 
 ```bash
 sudo -iu openclaw
@@ -230,7 +249,9 @@ printf '%s' "$ANTHROPIC_API_KEY" | podman secret create anthropic_api_key -
 printf '%s' "$OPENAI_API_KEY" | podman secret create openai_api_key -
 ```
 
-Then sync the generated Quadlet drop-ins and OpenClaw SecretRefs:
+### Applying Secrets
+
+Sync the generated Quadlet drop-ins and OpenClaw SecretRefs:
 
 ```bash
 tank-openclaw-secrets


### PR DESCRIPTION
After provisioning a new virtual machine, `openclaw.service` fails to start; `Refusing to bind gateway to lan without auth`

```
Jun 09 19:46:44 tank-os openclaw[4082]: cd7a204083bf66b6eed18af3ddab20d3f2ba110f3a4b9499ea3332cf59586929
Jun 09 19:46:45 tank-os openclaw[4092]: 2026-06-09T19:46:45.119+00:00 [gateway] loading configuration…
Jun 09 19:46:45 tank-os openclaw[4092]: 2026-06-09T19:46:45.202+00:00 [gateway] resolving authentication…
Jun 09 19:46:45 tank-os openclaw[4092]: 2026-06-09T19:46:45.209+00:00 Refusing to bind gateway to lan without auth.
Jun 09 19:46:45 tank-os openclaw[4092]: Container environment detected — the gateway defaults to bind=auto (0.0.0.0) for port-forwarding compatibility.
Jun 09 19:46:45 tank-os openclaw[4092]: Set OPENCLAW_GATEWAY_TOKEN or OPENCLAW_GATEWAY_PASSWORD, or pass --token/--password *** start with auth.
```

Updated `bootc/rootfs/usr/libexec/tank-os/sync-podman-secrets` to provision `OPENCLAW_GATEWAY_TOKEN` using `podman secrets` as described here - https://github.com/nicholasburr/tank-os/blob/main/docs/provisioning.md#podman-secrets

After the secret is applied the gateway continues startup as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for syncing the OpenClaw Gateway token as a Podman secret.

* **Documentation**
  * Enhanced provisioning guide with step-by-step instructions for configuring the Gateway token, Anthropic API key, and OpenAI API key.
  * Added post-boot connection and secret synchronization guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->