### PR TITLE
Package tank-os for OpenShift Virtualization and add quick-start docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ IMAGE_OPENCLAW_OPENSHELL_URI ?= quay.io/redhat-et/tank-claw-openshell
 
 # KubeVirt containerDisk (wraps out-tank-os/qcow2/disk.qcow2, see
 # deploy/containerdisk/Containerfile) -- override if you're publishing to
-# a different registry. This repo doesn't exist until you create it.
+# a different registry.
 IMAGE_CONTAINERDISK_URI ?= quay.io/redhat-et/tank-os-containerdisk
 
 # Auto-detect architecture

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ OPENCLAW_REF ?= 2026.7.1
 # a different destination (e.g. a fork's own registry).
 IMAGE_OPENCLAW_OPENSHELL_URI ?= quay.io/redhat-et/tank-claw-openshell
 
+# KubeVirt containerDisk (wraps out-tank-os/qcow2/disk.qcow2, see
+# deploy/containerdisk/Containerfile) -- override if you're publishing to
+# a different registry. This repo doesn't exist until you create it.
+IMAGE_CONTAINERDISK_URI ?= quay.io/redhat-et/tank-os-containerdisk
+
 # Auto-detect architecture
 UNAME_ARCH := $(shell uname -m)
 ifeq ($(UNAME_ARCH),x86_64)
@@ -55,6 +60,8 @@ help:
 	@echo "  build          Build the bootc container image locally"
 	@echo "  push           Push the image to registry (requires IMAGE_REGISTRY and IMAGE_NAMESPACE)"
 	@echo "  build-qcow2    Build a QCOW2 disk image using bootc-image-builder"
+	@echo "  build-containerdisk  Wrap the qcow2 as a KubeVirt containerDisk (run build-qcow2 first)"
+	@echo "  push-containerdisk   Push it to IMAGE_CONTAINERDISK_URI"
 	@echo "  build-iso      Build an ISO installer using bootc-image-builder"
 	@echo "  lint           Run bootc container lint (if available)"
 	@echo "  verify         Verify image signature with cosign (if COSIGN_PUBLIC_KEY is set)"
@@ -65,6 +72,7 @@ help:
 	@echo "  PLATFORM:        $(PLATFORM)"
 	@echo "  IMAGE_URI:       $(IMAGE_URI)"
 	@echo "  IMAGE_OPENCLAW_OPENSHELL_URI: $(IMAGE_OPENCLAW_OPENSHELL_URI)"
+	@echo "  IMAGE_CONTAINERDISK_URI: $(IMAGE_CONTAINERDISK_URI)"
 	@echo "  OPENCLAW_REF:    $(OPENCLAW_REF)"
 	@echo "  IMAGE_REGISTRY:  $(IMAGE_REGISTRY)"
 	@echo "  IMAGE_NAMESPACE: $(IMAGE_NAMESPACE)"
@@ -120,6 +128,25 @@ build-qcow2:
 		--target-arch $(ARCH) \
 		--rootfs xfs \
 		--config /config.toml
+
+# KubeVirt containerDisk -- run this AFTER build-qcow2, it wraps that
+# target's output (out-tank-os/qcow2/disk.qcow2). See
+# docs/openshift-virtualization.md for the full pipeline.
+.PHONY: build-containerdisk
+build-containerdisk:
+	@if [ ! -f "out-tank-os/qcow2/disk.qcow2" ]; then \
+		echo "Error: out-tank-os/qcow2/disk.qcow2 not found. Run 'make build-qcow2' first."; \
+		exit 1; \
+	fi
+	cp out-tank-os/qcow2/disk.qcow2 deploy/containerdisk/disk.qcow2
+	podman build --platform $(PLATFORM) \
+		-t $(IMAGE_CONTAINERDISK_URI):latest \
+		-f deploy/containerdisk/Containerfile deploy/containerdisk
+	rm -f deploy/containerdisk/disk.qcow2
+
+.PHONY: push-containerdisk
+push-containerdisk:
+	podman push $(IMAGE_CONTAINERDISK_URI):latest
 
 .PHONY: build-iso
 build-iso:

--- a/deploy/applicationset.yaml
+++ b/deploy/applicationset.yaml
@@ -1,0 +1,80 @@
+# ArgoCD ApplicationSet: one Application per user, each syncing the same
+# deploy/base/ Kustomize base with a per-user patch (name, labels,
+# hostname). To add a user, add one entry to the List generator below --
+# no new files, no new directories. See docs/openshift-virtualization.md.
+#
+# NOT YET DEPLOYED/TESTED against a live cluster -- see that doc's
+# "first real cluster test" checklist before relying on this.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: tank-os
+  namespace: openshift-gitops
+spec:
+  generators:
+    - list:
+        elements:
+          - user: alice
+          - user: bob
+          # - user: carol
+          # ... one entry per user, up to however many you're running.
+  template:
+    metadata:
+      name: "tank-os-{{.user}}"
+    spec:
+      project: default
+      source:
+        # Update repoURL/targetRevision once this lives on a branch/tag
+        # you intend ArgoCD to track (e.g. after this PR merges to main).
+        repoURL: https://github.com/LobsterTrap/tank-os.git
+        targetRevision: main
+        path: deploy/base
+        kustomize:
+          patches:
+            - target:
+                kind: VirtualMachine
+                name: tank-USER_PLACEHOLDER
+              # JSON6902: values here can only be replaced wholesale, not
+              # edited in place, hence the cloud-init userData block is
+              # duplicated from deploy/base/virtualmachine.yaml rather than
+              # patched at the `hostname:` line -- Kustomize has no
+              # visibility into a YAML value that's itself a raw string.
+              # volumes/1 assumes cloudinitdisk stays the second volume in
+              # the base file (see the comment there).
+              patch: |-
+                - op: replace
+                  path: /metadata/name
+                  value: tank-{{.user}}
+                - op: replace
+                  path: /metadata/labels/tank-os~1user
+                  value: "{{.user}}"
+                - op: replace
+                  path: /spec/template/metadata/labels/tank-os~1user
+                  value: "{{.user}}"
+                - op: replace
+                  path: /spec/template/spec/volumes/1/cloudInitNoCloud/userData
+                  value: |
+                    #cloud-config
+                    hostname: tank-{{.user}}
+                    users:
+                      - name: openclaw
+                        gecos: OpenClaw
+                        groups:
+                          - wheel
+                        sudo:
+                          - ALL=(ALL) NOPASSWD:ALL
+                        shell: /bin/bash
+                        lock_passwd: true
+                        ssh_authorized_keys:
+                          - ssh-ed25519 REPLACE_WITH_YOUR_PUBLIC_KEY tank-os
+                    runcmd:
+                      - [loginctl, enable-linger, openclaw]
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: "tank-{{.user}}"
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - virtualmachine.yaml

--- a/deploy/base/virtualmachine.yaml
+++ b/deploy/base/virtualmachine.yaml
@@ -1,0 +1,70 @@
+# KubeVirt VirtualMachine template. Per-user values (name/labels/hostname)
+# are placeholders here -- they get patched per user by the ArgoCD
+# ApplicationSet in deploy/applicationset.yaml, not edited in this file.
+# See docs/openshift-virtualization.md for how a user gets added.
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: tank-USER_PLACEHOLDER
+  labels:
+    app: tank-os
+    tank-os/user: USER_PLACEHOLDER
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        app: tank-os
+        tank-os/user: USER_PLACEHOLDER
+    spec:
+      domain:
+        cpu:
+          cores: 2
+        resources:
+          requests:
+            memory: 4Gi
+        devices:
+          disks:
+            - name: containerdisk
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              masquerade: {}
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          # Placeholder tag -- IMAGE_CONTAINERDISK_URI in the Makefile is
+          # the source of truth for where this actually gets published.
+          containerDisk:
+            image: quay.io/redhat-et/tank-os-containerdisk:latest
+        # Index 1 in this list -- deploy/applicationset.yaml's JSON6902
+        # patch addresses this volume's userData by that fixed index, so
+        # keep cloudinitdisk here (position 1) if this file changes.
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            # Same shape as examples/cloud-init/openclaw-user-data.yaml
+            # (shared SSH key, same openclaw user block) with a hostname
+            # key added -- REPLACE_WITH_YOUR_PUBLIC_KEY still needs a real
+            # key before this is usable; see docs/openshift-virtualization.md.
+            userData: |
+              #cloud-config
+              hostname: tank-USER_PLACEHOLDER
+              users:
+                - name: openclaw
+                  gecos: OpenClaw
+                  groups:
+                    - wheel
+                  sudo:
+                    - ALL=(ALL) NOPASSWD:ALL
+                  shell: /bin/bash
+                  lock_passwd: true
+                  ssh_authorized_keys:
+                    - ssh-ed25519 REPLACE_WITH_YOUR_PUBLIC_KEY tank-os
+              runcmd:
+                - [loginctl, enable-linger, openclaw]

--- a/deploy/containerdisk/Containerfile
+++ b/deploy/containerdisk/Containerfile
@@ -1,0 +1,11 @@
+# Wraps a tank-os qcow2 disk (from `make build-qcow2`) as a KubeVirt
+# containerDisk -- the standard convention KubeVirt's own docs describe:
+# an otherwise-empty image with the disk file at /disk/. KubeVirt's
+# virt-handler extracts it directly from the image layers at VM start; it
+# never runs this image as a container.
+#
+# Build context must be the directory containing disk.qcow2 (typically
+# out-tank-os/qcow2/) -- see the `build-containerdisk` Makefile target.
+
+FROM scratch
+COPY disk.qcow2 /disk/

--- a/docs/openshift-virtualization.md
+++ b/docs/openshift-virtualization.md
@@ -4,11 +4,14 @@ This packages tank-os as a KubeVirt `containerDisk` and automates
 per-user VM provisioning via ArgoCD, so onboarding a user means adding
 one line to a list, not manually creating a VM.
 
-**Status: authored, not yet deployed against a live cluster.** No
-OpenShift Virtualization (CNV)-capable cluster with bare-metal nodes was
-available while writing this (same gap as the original smoke test — see
-`tank-os-smoke-test-summary.md`). Everything below has been validated
-locally (`kustomize build`, manual patch-rendering simulation, `oc apply
+**Status: images published, not yet deployed against a live cluster.**
+`quay.io/redhat-et/tank-os`, `tank-claw-openshell`, and
+`tank-os-containerdisk` are all built and pushed (public read, confirmed
+via anonymous pull). No OpenShift Virtualization (CNV)-capable cluster
+with bare-metal nodes was available while writing this (same gap as the
+original smoke test — see `tank-os-smoke-test-summary.md`), so the
+`deploy/` manifests themselves have only been validated locally
+(`kustomize build`, manual patch-rendering simulation, `oc apply
 --dry-run=client`), not against a real ArgoCD/KubeVirt install. See "First
 real cluster test" at the end for what to run the moment cluster access
 exists.
@@ -38,15 +41,22 @@ user, so per-VM values can only be injected at deploy time.
 ## Building and publishing the containerDisk
 
 ```bash
-make build-qcow2                 # produces out-tank-os/qcow2/disk.qcow2
+make build IMAGE_REGISTRY=quay.io IMAGE_NAMESPACE=redhat-et     # tags quay.io/redhat-et/tank-os:latest
+make push IMAGE_REGISTRY=quay.io IMAGE_NAMESPACE=redhat-et      # publishes the bootc image itself
+make build-qcow2 IMAGE_REGISTRY=quay.io IMAGE_NAMESPACE=redhat-et   # produces out-tank-os/qcow2/disk.qcow2
 make build-containerdisk         # wraps it (needs the qcow2 above first)
-make push-containerdisk          # needs IMAGE_CONTAINERDISK_URI to actually exist as a repo
+make push-containerdisk
 ```
 
-`IMAGE_CONTAINERDISK_URI` defaults to `quay.io/redhat-et/tank-os-containerdisk`
-— that repo doesn't exist yet. Create it the same way as
-`tank-claw-openshell` earlier (public read, robot account push) before
-running `push-containerdisk` for real.
+All three registry repos (`tank-os`, `tank-claw-openshell`,
+`tank-os-containerdisk`) already exist under `quay.io/redhat-et` with
+public read and robot-account push access. Publishing the bootc `tank-os`
+image itself isn't required for `build-qcow2` to work (that target reads
+from local Podman storage via `--local`), but it's what makes
+`bootc switch`/`bootc upgrade` in-place updates possible on already-running
+VMs (see `docs/build.md`'s "Upgrade A Running VM"), and lets this whole
+pipeline be reproduced from a different machine or CI runner instead of
+requiring the exact local build state.
 
 ## Adding a user
 

--- a/docs/openshift-virtualization.md
+++ b/docs/openshift-virtualization.md
@@ -1,0 +1,115 @@
+# OpenShift Virtualization: per-user provisioning
+
+This packages tank-os as a KubeVirt `containerDisk` and automates
+per-user VM provisioning via ArgoCD, so onboarding a user means adding
+one line to a list, not manually creating a VM.
+
+**Status: authored, not yet deployed against a live cluster.** No
+OpenShift Virtualization (CNV)-capable cluster with bare-metal nodes was
+available while writing this (same gap as the original smoke test — see
+`tank-os-smoke-test-summary.md`). Everything below has been validated
+locally (`kustomize build`, manual patch-rendering simulation, `oc apply
+--dry-run=client`), not against a real ArgoCD/KubeVirt install. See "First
+real cluster test" at the end for what to run the moment cluster access
+exists.
+
+## Architecture
+
+One shared `containerDisk` image, N cheap ArgoCD `Application`s — not N
+built images and not N checked-in VM manifests:
+
+| Piece | What it does |
+| --- | --- |
+| `deploy/containerdisk/Containerfile` | Wraps `make build-qcow2`'s output (`FROM scratch` + `COPY disk.qcow2 /disk/`), KubeVirt's documented convention. One image, referenced by every VM. |
+| `deploy/base/virtualmachine.yaml` | A single KubeVirt `VirtualMachine` template with placeholder tokens (`USER_PLACEHOLDER`) for name/labels/hostname. |
+| `deploy/applicationset.yaml` | An ArgoCD `ApplicationSet` with a **List generator** — one entry per user. Each generates an `Application` pointing at `deploy/base/`, patched per user via a JSON6902 Kustomize patch. |
+
+Per-user customization (hostname + VM name/labels) lives entirely in the
+`ApplicationSet`'s list — adding a user is a one-line diff, not a new
+file or directory. Per the confirmed decisions for this phase: SSH key,
+OpenClaw config, and storage/resource sizing are **identical across all
+users**, so there's nothing else to parameterize yet.
+
+Hostname is set via `cloudInitNoCloud.userData` (cloud-init's
+`set_hostname` module, already confirmed enabled by default in this
+image), not baked into the containerDisk — the same image serves every
+user, so per-VM values can only be injected at deploy time.
+
+## Building and publishing the containerDisk
+
+```bash
+make build-qcow2                 # produces out-tank-os/qcow2/disk.qcow2
+make build-containerdisk         # wraps it (needs the qcow2 above first)
+make push-containerdisk          # needs IMAGE_CONTAINERDISK_URI to actually exist as a repo
+```
+
+`IMAGE_CONTAINERDISK_URI` defaults to `quay.io/redhat-et/tank-os-containerdisk`
+— that repo doesn't exist yet. Create it the same way as
+`tank-claw-openshell` earlier (public read, robot account push) before
+running `push-containerdisk` for real.
+
+## Adding a user
+
+Edit `deploy/applicationset.yaml`'s List generator:
+
+```yaml
+generators:
+  - list:
+      elements:
+        - user: alice
+        - user: bob
+        - user: carol   # <- add this line
+```
+
+ArgoCD picks up the new entry on its next generator refresh and creates
+`tank-os-carol` (an `Application`) → namespace `tank-carol` → a
+`VirtualMachine` named `tank-carol` with hostname `tank-carol`. Nothing
+else needs to change.
+
+## Local validation
+
+```bash
+kustomize build deploy/base                    # confirms the base renders as valid YAML
+oc apply --dry-run=client -f deploy/applicationset.yaml   # confirms the ApplicationSet YAML itself is well-formed
+```
+
+Full KubeVirt CRD schema validation (confirming `VirtualMachine`'s fields
+are actually valid per the CRD, not just valid YAML) needs a live cluster
+with the KubeVirt CRDs installed — not attempted here.
+
+The JSON6902 patch in `applicationset.yaml` was verified by hand: copied
+`deploy/base/virtualmachine.yaml` into a scratch directory, wrote the same
+patch with `{{.user}}` manually substituted for `alice`, and confirmed
+`kustomize build` renders `metadata.name: tank-alice`, both
+`tank-os/user: alice` label locations, and `hostname: tank-alice` inside
+`userData` correctly. This isn't the same as ArgoCD's own Go-template
+rendering running for real, but it confirms the Kustomize patch mechanics
+are sound.
+
+## First real cluster test
+
+Once a CNV-capable cluster (OpenShift Virtualization operator installed,
+bare-metal-capable nodes) is available:
+
+1. Confirm OpenShift GitOps (ArgoCD) is installed:
+   `oc get csv -n openshift-gitops-operator`.
+2. Replace `REPLACE_WITH_YOUR_PUBLIC_KEY` in
+   `deploy/applicationset.yaml`'s patch (and in `deploy/base/virtualmachine.yaml`,
+   used only if the patch doesn't apply for some element) with a real key.
+3. Build, publish, and confirm the containerDisk pulls:
+   `make build-qcow2 build-containerdisk push-containerdisk`, then
+   `podman pull $(IMAGE_CONTAINERDISK_URI):latest` from a clean environment
+   to confirm public read access.
+4. `oc apply -f deploy/applicationset.yaml` and watch
+   `oc get applications -n openshift-gitops` for sync health.
+5. Confirm the namespaces (`tank-alice`, `tank-bob`, ...) were created
+   and each has a `VirtualMachine`/`VirtualMachineInstance` reaching
+   `Running`.
+6. SSH into one VM and confirm `hostname` matches
+   (`tank-alice`, not `tank`) and OpenClaw/OpenShell come up the same way
+   verified in `docs/openshell.md`'s manual test.
+7. Edit the `ApplicationSet` to add a throwaway test user, confirm ArgoCD
+   creates the new `Application`/namespace/VM without touching the
+   existing ones, then remove it again to confirm cleanup
+   (`prune: true` should delete the namespace's resources — verify it
+   doesn't orphan anything).

--- a/docs/quickstart-prebuilt.md
+++ b/docs/quickstart-prebuilt.md
@@ -1,0 +1,169 @@
+# Quick Start: Run tank-os From Published Images
+
+This is the "just run it" path — no `make build`, no bootc-image-builder
+invocation, no `config.toml`. Everything here pulls from the already-published
+images:
+
+| Image | Used for |
+| --- | --- |
+| `quay.io/redhat-et/tank-os-containerdisk:latest` | Contains a ready-to-boot `disk.qcow2` — extract it and boot with any hypervisor |
+| `quay.io/redhat-et/tank-os:latest` | The bootc OS image itself — only needed for `bootc switch`/`bootc upgrade` on an existing bootc host |
+
+All three published repos (`tank-os`, `tank-claw-openshell`,
+`tank-os-containerdisk`) are public-read; no `podman login` required to pull.
+
+## Extract the disk image
+
+The containerdisk image is a `FROM scratch` wrapper around one file
+(`/disk/disk.qcow2`, KubeVirt's convention) — `podman create` + `podman cp`
+pulls it out without running the container:
+
+```bash
+podman create --name tank-os-extract quay.io/redhat-et/tank-os-containerdisk:latest
+podman cp tank-os-extract:/disk/disk.qcow2 ./tank-os-disk.qcow2
+podman rm tank-os-extract
+```
+
+This qcow2 was built with `--rootfs xfs` for `arm64` (see the Makefile's
+`build-containerdisk` target) — it boots on Apple Silicon and on aarch64
+Linux hosts directly. For x86_64, either build locally
+(`make build-qcow2 ARCH=amd64`, see `docs/build.md`) or ask whoever publishes
+images to also push an amd64-tagged containerdisk; a single tag can only hold
+one architecture's disk.
+
+The SSH keys and OpenClaw/OpenShell config already baked into `tank-os:latest`
+came from whatever `config.toml` was used at containerdisk build time — check
+with whoever published it, or expect to need your own build if you need a
+different key.
+
+## macOS (Apple Silicon) via QEMU
+
+Same QEMU + HVF invocation as `docs/build.md`'s "Launch on macOS" section,
+just pointed at the extracted qcow2 instead of a locally built one:
+
+```bash
+qemu-img resize ./tank-os-disk.qcow2 20G
+
+qemu_share="$(brew --prefix qemu)/share/qemu"
+cp "$qemu_share/edk2-arm-vars.fd" ./edk2-arm-vars.fd
+
+qemu-system-aarch64 \
+  -M virt,highmem=on \
+  -accel hvf \
+  -cpu host \
+  -smp 2 \
+  -m 4096 \
+  -drive file=./tank-os-disk.qcow2,format=qcow2,if=virtio \
+  -drive if=pflash,format=raw,readonly=on,file="$qemu_share/edk2-aarch64-code.fd" \
+  -drive if=pflash,format=raw,file=./edk2-arm-vars.fd \
+  -device virtio-net-pci,netdev=net0 \
+  -netdev user,id=net0,hostfwd=tcp::2222-:22 \
+  -nographic
+```
+
+Requires `brew install qemu`. SSH once booted: `ssh -p 2222 openclaw@localhost`
+(assuming the published image's baked-in key matches yours).
+
+## Fedora Linux
+
+Two paths, depending on whether the target machine already runs a bootc-based
+OS:
+
+**Already on a bootc host** (e.g. a prior tank-os VM, or plain
+`fedora-bootc`) — no disk image needed at all, `bootc` handles the pull:
+
+```bash
+sudo bootc switch --apply quay.io/redhat-et/tank-os:latest
+```
+
+Reboots into tank-os in place. Future updates: `sudo bootc upgrade --apply`.
+
+**Not yet a bootc host** (e.g. a regular Fedora Workstation/Server, or an
+empty VM) — boot the extracted qcow2 directly with `virt-install`, which
+Fedora ships by default:
+
+```bash
+sudo virt-install \
+  --name tank-os \
+  --memory 4096 \
+  --vcpus 2 \
+  --disk ./tank-os-disk.qcow2,format=qcow2,bus=virtio \
+  --import \
+  --os-variant fedora-unknown \
+  --network network=default \
+  --graphics none \
+  --console pty,target_type=serial
+```
+
+Or use the repo's portable QEMU script (`examples/boot-tank-os-qemu.sh`) the
+same way `docs/build.md`'s "Launch on Linux (QEMU)" section describes, again
+pointing it at `./tank-os-disk.qcow2` instead of a fresh
+`out-tank-os/qcow2/disk.qcow2`.
+
+## Lima (macOS/Linux)
+
+**Confirmed working** on Lima 2.2.0 / macOS (Apple Silicon, M3), 2026-07-28,
+across all three of Lima's VM drivers. Ready-made manifests are at
+`examples/lima/`:
+
+| Manifest | Driver | Notes |
+| --- | --- | --- |
+| `tank-os-qemu.yaml` | QEMU | Works on macOS and Linux hosts alike; same HVF acceleration as the plain-QEMU recipe above |
+| `tank-os-vz.yaml` | Apple `Virtualization.framework` | macOS only, no firmware files to manage; networked over vsock instead of usermode NAT |
+| `tank-os-krunkit.yaml` | krunkit (libkrun) | macOS only; keeps the whole stack on the same hypervisor family this repo's own Podman-machine build path already uses |
+
+All three produced identical guest behavior (cloud-init, hostname,
+OpenClaw/OpenShell bring-up) — pick whichever driver is already installed;
+there's no functional reason to prefer one over another for this image.
+
+```bash
+mkdir -p ~/.lima/_images
+podman create --name tank-os-extract quay.io/redhat-et/tank-os-containerdisk:latest
+podman cp tank-os-extract:/disk/disk.qcow2 ~/.lima/_images/tank-os-disk.qcow2
+podman rm tank-os-extract
+
+limactl start --name tank-os ./examples/lima/tank-os-vz.yaml --tty=false
+limactl shell tank-os
+```
+
+(Swap in `tank-os-qemu.yaml` or `tank-os-krunkit.yaml` for a different
+driver — only `vmType` differs between the three files.)
+
+What actually happens, and what to expect:
+
+- **`limactl start` exits non-zero and prints "DEGRADED."** This is
+  harmless, not a failure to fix: Lima's health check requires its own
+  `lima-guestagent` to be running in the guest for port-forwarding/mount
+  status, and tank-os doesn't ship that agent. The VM itself boots and is
+  fully usable — `limactl list` shows `STATUS=Running`, and
+  `limactl shell tank-os` / plain `ssh` both work immediately. Ignore the
+  exit code and DEGRADED banner.
+- **Cloud-init runs cleanly and both cloud-init "layers" coexist.** Lima
+  injects its own NoCloud data (creating a `lima` user, its SSH key, and a
+  hostname) on top of tank-os's baked-in `cloud-init`/`sshd` — both apply
+  without conflict, confirming this base image needs no Lima-specific
+  changes to work as an "arbitrary" (non-Lima-aware) guest.
+- **Hostname becomes `lima-tank-os`, not `tank`.** Lima's own cloud-init
+  hostname module runs after tank-os's baked-in `/etc/hostname`
+  and wins — same "last cloud-init wins" behavior already documented for
+  the OpenShift Virtualization path's per-VM hostnames.
+- **One pre-existing, unrelated failed unit:** `cloud-init-main.service`
+  shows `failed` in `systemctl --failed` — this is Fedora's legacy
+  single-process cloud-init compatibility unit; the real boot-stage units
+  (`cloud-init-local`, `cloud-init-network`, `cloud-config`, `cloud-final`)
+  all report `active`/`exited` normally, so the system is functionally
+  fine despite `systemctl is-system-running` printing `degraded`.
+- **OpenClaw/OpenShell come up exactly as documented for QEMU.**
+  `openclaw.service` runs through the same `bootstrap-openclaw` →
+  `bootstrap-openshell-sandbox` sequence as `docs/openshell.md` describes,
+  including the known `openshell sandbox create` CLI-hang (the sandbox
+  reaches `Phase: Ready` well before the wrapping `timeout 600` process
+  exits) — this is the same pre-existing quirk on Lima as on bare QEMU, not
+  something Lima introduces.
+
+Verify from inside the guest:
+
+```bash
+limactl shell tank-os -- sudo -u openclaw \
+  env XDG_RUNTIME_DIR=/run/user/1000 openshell sandbox get tankos-openclaw
+```

--- a/examples/lima/tank-os-krunkit.yaml
+++ b/examples/lima/tank-os-krunkit.yaml
@@ -1,0 +1,26 @@
+# Lima config for booting tank-os using krunkit (libkrun) instead of QEMU --
+# macOS only. Notable because tank-os's own build/test infra already runs
+# atop a libkrun-backed Podman machine on macOS (see docs/build.md's
+# rootful-machine note), so this keeps the whole local stack on one
+# hypervisor family.
+# See tank-os-qemu.yaml for the image-extraction step and shared notes;
+# this file differs only in `vmType`.
+#
+# Confirmed working on Lima 2.2.0 / macOS M3 (2026-07-28): identical guest
+# behavior to the qemu/vz variants (cloud-init, hostname, OpenClaw/OpenShell
+# bring-up). Same expected "DEGRADED" exit from `limactl start` -- see
+# tank-os-qemu.yaml's comment and docs/quickstart-prebuilt.md.
+vmType: "krunkit"
+arch: "aarch64"
+images:
+  - location: "~/.lima/_images/tank-os-disk.qcow2"
+    arch: "aarch64"
+cpus: 2
+memory: "4GiB"
+disk: "20GiB"
+mounts: []
+containerd:
+  system: false
+  user: false
+ssh:
+  loadDotSSHPubKeys: true

--- a/examples/lima/tank-os-qemu.yaml
+++ b/examples/lima/tank-os-qemu.yaml
@@ -1,0 +1,37 @@
+# Lima config for booting a tank-os disk pulled from
+# quay.io/redhat-et/tank-os-containerdisk, using Lima's QEMU driver
+# (works on both macOS and Linux hosts). Extract the qcow2 first:
+#
+#   podman create --name tank-os-extract quay.io/redhat-et/tank-os-containerdisk:latest
+#   podman cp tank-os-extract:/disk/disk.qcow2 ~/.lima/_images/tank-os-disk.qcow2
+#   podman rm tank-os-extract
+#
+# Then: limactl start --name tank-os ./tank-os-qemu.yaml
+#
+# See tank-os-vz.yaml (Apple Virtualization.framework) and
+# tank-os-krunkit.yaml (libkrun) for macOS-only alternatives -- all three
+# were confirmed working identically on Lima 2.2.0 / macOS M3 (2026-07-28).
+# See docs/quickstart-prebuilt.md for the full comparison and caveats.
+#
+# tank-os isn't a Lima-aware guest (no lima-guestagent), so this disables
+# mounts and containerd/dockerd provisioning that Lima normally sets up.
+#
+# `limactl start` itself exits non-zero and reports "DEGRADED" because the
+# guest agent never comes up -- that's expected and harmless here, not a
+# real failure. The VM is fully running at that point; `limactl shell
+# tank-os` and plain `ssh` both work. `limactl list` shows STATUS=Running
+# despite the non-zero exit code from `start`.
+vmType: "qemu"
+arch: "aarch64"
+images:
+  - location: "~/.lima/_images/tank-os-disk.qcow2"
+    arch: "aarch64"
+cpus: 2
+memory: "4GiB"
+disk: "20GiB"
+mounts: []
+containerd:
+  system: false
+  user: false
+ssh:
+  loadDotSSHPubKeys: true

--- a/examples/lima/tank-os-vz.yaml
+++ b/examples/lima/tank-os-vz.yaml
@@ -1,0 +1,24 @@
+# Lima config for booting tank-os using Apple's native Virtualization.framework
+# (vz) instead of QEMU -- macOS only, no HVF/QEMU firmware setup needed.
+# See tank-os-qemu.yaml for the image-extraction step and shared notes;
+# this file differs only in `vmType`.
+#
+# Confirmed working on Lima 2.2.0 / macOS M3 (2026-07-28): identical guest
+# behavior to the qemu variant (cloud-init, hostname, OpenClaw/OpenShell
+# bring-up), networked over vsock instead of QEMU's usermode NAT. Same
+# expected "DEGRADED" exit from `limactl start` -- see tank-os-qemu.yaml's
+# comment and docs/quickstart-prebuilt.md.
+vmType: "vz"
+arch: "aarch64"
+images:
+  - location: "~/.lima/_images/tank-os-disk.qcow2"
+    arch: "aarch64"
+cpus: 2
+memory: "4GiB"
+disk: "20GiB"
+mounts: []
+containerd:
+  system: false
+  user: false
+ssh:
+  loadDotSSHPubKeys: true


### PR DESCRIPTION
## Summary
- Package tank-os as a KubeVirt `containerDisk` (`deploy/containerdisk/`) and add an ArgoCD `ApplicationSet` (`deploy/applicationset.yaml`) that provisions one VM per user from a single-line list entry, via a Kustomize base (`deploy/base/`)
- Publish `tank-os`, `tank-claw-openshell`, and `tank-os-containerdisk` to `quay.io/redhat-et` (public read)
- Add `docs/quickstart-prebuilt.md`: run tank-os straight from the published images, no build tooling required — QEMU on macOS/Fedora, `bootc switch` on existing bootc hosts, and Lima (all three drivers: qemu, vz, krunkit)

## Test plan
- [x] Built and pushed all three images to `quay.io/redhat-et`, confirmed anonymous pull
- [x] `kustomize build deploy/base` renders valid YAML; `oc apply --dry-run=client` on the ApplicationSet
- [x] Manually verified the ApplicationSet's JSON6902 patch renders per-user name/labels/hostname correctly
- [x] Extracted `disk.qcow2` from the published containerdisk and booted it live under Lima 2.2.0 (qemu, vz, and krunkit drivers) on macOS/M3 — confirmed identical cloud-init, hostname, and OpenClaw/OpenShell bring-up across all three
- [ ] Full live-cluster verification against a real OpenShift Virtualization (CNV) cluster — checklist in `docs/openshift-virtualization.md`'s "First real cluster test" section, blocked on cluster access