### PR TITLE
feat: package tank-os for OpenShift Virtualization and add quick-start docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,8 @@ help:
 	@echo "  push           Push the image to registry (requires IMAGE_REGISTRY and IMAGE_NAMESPACE)"
 	@echo "  build-qcow2    Build a QCOW2 disk image using bootc-image-builder"
 	@echo "  build-containerdisk  Wrap the qcow2 as a KubeVirt containerDisk (run build-qcow2 first)"
-	@echo "  push-containerdisk   Push it to IMAGE_CONTAINERDISK_URI"
+	@echo "  push-containerdisk   Push it to IMAGE_CONTAINERDISK_URI:latest (single-arch, see WARNING)"
+	@echo "  push-containerdisk-arch  Push it to IMAGE_CONTAINERDISK_URI:\$$(ARCH), safe for multi-arch merge"
 	@echo "  build-iso      Build an ISO installer using bootc-image-builder"
 	@echo "  lint           Run bootc container lint (if available)"
 	@echo "  verify         Verify image signature with cosign (if COSIGN_PUBLIC_KEY is set)"
@@ -160,7 +161,29 @@ build-containerdisk:
 
 .PHONY: push-containerdisk
 push-containerdisk:
+	@echo "WARNING: $(IMAGE_CONTAINERDISK_URI):latest is expected to be a"; \
+	echo "multi-arch manifest list. This target pushes a single-arch"; \
+	echo "($(ARCH)) image straight to that tag, which silently REPLACES the"; \
+	echo "manifest list with a single-arch image -- breaking every other"; \
+	echo "architecture's pull. If you're updating the shared published"; \
+	echo "image, push each arch under its own tag instead and merge with"; \
+	echo "'podman manifest create/add' + 'push --all' -- see"; \
+	echo "docs/openshift-virtualization.md's \"Publishing a multi-arch"; \
+	echo "containerdisk\" section. Only push straight to :latest for a"; \
+	echo "personal single-arch build you don't intend anyone else to pull."
 	podman push $(IMAGE_CONTAINERDISK_URI):latest
+
+# Safe building block for publishing a multi-arch containerdisk -- pushes
+# under an arch-specific tag instead of :latest, so it can never clobber
+# the published manifest list. Run on each architecture's own native
+# host, then merge the resulting tags into a manifest list with `podman
+# manifest create`/`push --all` -- see
+# docs/openshift-virtualization.md's "Publishing a multi-arch
+# containerdisk" section for the exact commands.
+.PHONY: push-containerdisk-arch
+push-containerdisk-arch:
+	podman tag $(IMAGE_CONTAINERDISK_URI):latest $(IMAGE_CONTAINERDISK_URI):$(ARCH)
+	podman push $(IMAGE_CONTAINERDISK_URI):$(ARCH)
 
 .PHONY: build-iso
 build-iso:
@@ -213,3 +236,4 @@ verify:
 .PHONY: clean
 clean:
 	rm -rf out-tank-os
+	rm -f deploy/containerdisk/disk.qcow2

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ OPENSHELL_VERSION ?= 0.0.92
 # a different destination (e.g. a fork's own registry).
 IMAGE_OPENCLAW_OPENSHELL_URI ?= quay.io/redhat-et/tank-claw-openshell
 
+# KubeVirt containerDisk (wraps out-tank-os/qcow2/disk.qcow2, see
+# deploy/containerdisk/Containerfile) -- override if you're publishing to
+# a different registry. This repo doesn't exist until you create it.
+IMAGE_CONTAINERDISK_URI ?= quay.io/redhat-et/tank-os-containerdisk
+
 # Auto-detect architecture
 UNAME_ARCH := $(shell uname -m)
 ifeq ($(UNAME_ARCH),x86_64)
@@ -61,6 +66,8 @@ help:
 	@echo "  build          Build the bootc container image locally"
 	@echo "  push           Push the image to registry (requires IMAGE_REGISTRY and IMAGE_NAMESPACE)"
 	@echo "  build-qcow2    Build a QCOW2 disk image using bootc-image-builder"
+	@echo "  build-containerdisk  Wrap the qcow2 as a KubeVirt containerDisk (run build-qcow2 first)"
+	@echo "  push-containerdisk   Push it to IMAGE_CONTAINERDISK_URI"
 	@echo "  build-iso      Build an ISO installer using bootc-image-builder"
 	@echo "  lint           Run bootc container lint (if available)"
 	@echo "  verify         Verify image signature with cosign (if COSIGN_PUBLIC_KEY is set)"
@@ -71,6 +78,7 @@ help:
 	@echo "  PLATFORM:        $(PLATFORM)"
 	@echo "  IMAGE_URI:       $(IMAGE_URI)"
 	@echo "  IMAGE_OPENCLAW_OPENSHELL_URI: $(IMAGE_OPENCLAW_OPENSHELL_URI)"
+	@echo "  IMAGE_CONTAINERDISK_URI: $(IMAGE_CONTAINERDISK_URI)"
 	@echo "  OPENCLAW_REF:    $(OPENCLAW_REF)"
 	@echo "  OPENSHELL_VERSION: $(OPENSHELL_VERSION)"
 	@echo "  IMAGE_REGISTRY:  $(IMAGE_REGISTRY)"
@@ -134,6 +142,25 @@ build-qcow2:
 		--target-arch $(ARCH) \
 		--rootfs xfs \
 		--config /config.toml
+
+# KubeVirt containerDisk -- run this AFTER build-qcow2, it wraps that
+# target's output (out-tank-os/qcow2/disk.qcow2). See
+# docs/openshift-virtualization.md for the full pipeline.
+.PHONY: build-containerdisk
+build-containerdisk:
+	@if [ ! -f "out-tank-os/qcow2/disk.qcow2" ]; then \
+		echo "Error: out-tank-os/qcow2/disk.qcow2 not found. Run 'make build-qcow2' first."; \
+		exit 1; \
+	fi
+	cp out-tank-os/qcow2/disk.qcow2 deploy/containerdisk/disk.qcow2
+	podman build --platform $(PLATFORM) \
+		-t $(IMAGE_CONTAINERDISK_URI):latest \
+		-f deploy/containerdisk/Containerfile deploy/containerdisk
+	rm -f deploy/containerdisk/disk.qcow2
+
+.PHONY: push-containerdisk
+push-containerdisk:
+	podman push $(IMAGE_CONTAINERDISK_URI):latest
 
 .PHONY: build-iso
 build-iso:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ IMAGE_OPENCLAW_OPENSHELL_URI ?= quay.io/redhat-et/tank-claw-openshell
 
 # KubeVirt containerDisk (wraps out-tank-os/qcow2/disk.qcow2, see
 # deploy/containerdisk/Containerfile) -- override if you're publishing to
-# a different registry. This repo doesn't exist until you create it.
+# a different registry.
 IMAGE_CONTAINERDISK_URI ?= quay.io/redhat-et/tank-os-containerdisk
 
 # Auto-detect architecture

--- a/README.md
+++ b/README.md
@@ -39,10 +39,12 @@ or tightly scoped sudo policy for OS management and bootc updates.
 ## Start Here
 
 - Build the image: [docs/build.md](docs/build.md)
+- Run it without building anything: [docs/quickstart-prebuilt.md](docs/quickstart-prebuilt.md)
 - Configure login access: [docs/provisioning.md](docs/provisioning.md)
 - Use the OpenClaw CLI: [docs/cli.md](docs/cli.md)
 - Configure model provider keys: [docs/model-providers.md](docs/model-providers.md)
 - Configure service-gator: [docs/service-gator.md](docs/service-gator.md)
+- Deploy per-user VMs on OpenShift Virtualization: [docs/openshift-virtualization.md](docs/openshift-virtualization.md)
 
 For bootc concepts and day-2 operations, see the upstream [bootc documentation](https://bootc-dev.github.io/bootc/).
 For disk image builds, see the [Podman Desktop BootC extension](https://github.com/podman-desktop/extension-bootc)

--- a/deploy/applicationset.yaml
+++ b/deploy/applicationset.yaml
@@ -3,14 +3,24 @@
 # hostname). To add a user, add one entry to the List generator below --
 # no new files, no new directories. See docs/openshift-virtualization.md.
 #
-# NOT YET DEPLOYED/TESTED against a live cluster -- see that doc's
-# "first real cluster test" checklist before relying on this.
+# Confirmed working on a live OpenShift GitOps install (2026-07-29) -- see
+# docs/openshift-virtualization.md's "First real cluster test" section for
+# what was verified and the one known gap (namespace cleanup on removal).
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: tank-os
   namespace: openshift-gitops
 spec:
+  # Required for the {{.user}} (dot-prefixed) syntax used throughout this
+  # template -- without this, the ApplicationSet controller falls back to
+  # its legacy "fasttemplate" engine, which doesn't recognize {{.user}} at
+  # all and renders it as literal text. Every generated Application then
+  # gets the exact same literal name ("tank-os-{{.user}}"), which ArgoCD
+  # rejects with "contains applications with duplicate name" -- confirmed
+  # by hitting this exact error on a real cluster before adding this line.
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
   generators:
     - list:
         elements:

--- a/deploy/applicationset.yaml
+++ b/deploy/applicationset.yaml
@@ -23,9 +23,14 @@ spec:
   goTemplateOptions: ["missingkey=error"]
   generators:
     - list:
-        elements:
-          - user: alice
-          - user: bob
+        # No live entries by default -- applying this file as-is with a
+        # real ssh_authorized_keys value below would create real VMs
+        # nobody can log into, since alice/bob here are just examples.
+        # Replace REPLACE_WITH_YOUR_PUBLIC_KEY below with a real key, then
+        # uncomment the users you actually want.
+        elements: []
+          # - user: alice
+          # - user: bob
           # - user: carol
           # ... one entry per user, up to however many you're running.
   template:
@@ -51,6 +56,19 @@ spec:
               # visibility into a YAML value that's itself a raw string.
               # volumes/1 assumes cloudinitdisk stays the second volume in
               # the base file (see the comment there).
+              #
+              # Known fragility, accepted for now rather than redesigned:
+              # this whole userData block must be kept in sync by hand with
+              # deploy/base/virtualmachine.yaml's copy -- if that file's
+              # cloud-config shape changes (a new user field, a different
+              # runcmd) and this patch isn't updated to match, per-user VMs
+              # will silently diverge from the base instead of failing
+              # loudly. The real fix (move userData into a Kustomize
+              # ConfigMap/component so there's one source of truth) is a
+              # bigger restructuring of deploy/base's layout than this
+              # phase's scope covers -- worth doing before this pattern is
+              # copied to a second differently-shaped VM template, not
+              # urgent for the current single-template setup.
               patch: |-
                 - op: replace
                   path: /metadata/name

--- a/deploy/applicationset.yaml
+++ b/deploy/applicationset.yaml
@@ -1,0 +1,80 @@
+# ArgoCD ApplicationSet: one Application per user, each syncing the same
+# deploy/base/ Kustomize base with a per-user patch (name, labels,
+# hostname). To add a user, add one entry to the List generator below --
+# no new files, no new directories. See docs/openshift-virtualization.md.
+#
+# NOT YET DEPLOYED/TESTED against a live cluster -- see that doc's
+# "first real cluster test" checklist before relying on this.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: tank-os
+  namespace: openshift-gitops
+spec:
+  generators:
+    - list:
+        elements:
+          - user: alice
+          - user: bob
+          # - user: carol
+          # ... one entry per user, up to however many you're running.
+  template:
+    metadata:
+      name: "tank-os-{{.user}}"
+    spec:
+      project: default
+      source:
+        # Update repoURL/targetRevision once this lives on a branch/tag
+        # you intend ArgoCD to track (e.g. after this PR merges to main).
+        repoURL: https://github.com/LobsterTrap/tank-os.git
+        targetRevision: main
+        path: deploy/base
+        kustomize:
+          patches:
+            - target:
+                kind: VirtualMachine
+                name: tank-USER_PLACEHOLDER
+              # JSON6902: values here can only be replaced wholesale, not
+              # edited in place, hence the cloud-init userData block is
+              # duplicated from deploy/base/virtualmachine.yaml rather than
+              # patched at the `hostname:` line -- Kustomize has no
+              # visibility into a YAML value that's itself a raw string.
+              # volumes/1 assumes cloudinitdisk stays the second volume in
+              # the base file (see the comment there).
+              patch: |-
+                - op: replace
+                  path: /metadata/name
+                  value: tank-{{.user}}
+                - op: replace
+                  path: /metadata/labels/tank-os~1user
+                  value: "{{.user}}"
+                - op: replace
+                  path: /spec/template/metadata/labels/tank-os~1user
+                  value: "{{.user}}"
+                - op: replace
+                  path: /spec/template/spec/volumes/1/cloudInitNoCloud/userData
+                  value: |
+                    #cloud-config
+                    hostname: tank-{{.user}}
+                    users:
+                      - name: openclaw
+                        gecos: OpenClaw
+                        groups:
+                          - wheel
+                        sudo:
+                          - ALL=(ALL) NOPASSWD:ALL
+                        shell: /bin/bash
+                        lock_passwd: true
+                        ssh_authorized_keys:
+                          - ssh-ed25519 REPLACE_WITH_YOUR_PUBLIC_KEY tank-os
+                    runcmd:
+                      - [loginctl, enable-linger, openclaw]
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: "tank-{{.user}}"
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - virtualmachine.yaml

--- a/deploy/base/virtualmachine.yaml
+++ b/deploy/base/virtualmachine.yaml
@@ -1,0 +1,70 @@
+# KubeVirt VirtualMachine template. Per-user values (name/labels/hostname)
+# are placeholders here -- they get patched per user by the ArgoCD
+# ApplicationSet in deploy/applicationset.yaml, not edited in this file.
+# See docs/openshift-virtualization.md for how a user gets added.
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: tank-USER_PLACEHOLDER
+  labels:
+    app: tank-os
+    tank-os/user: USER_PLACEHOLDER
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        app: tank-os
+        tank-os/user: USER_PLACEHOLDER
+    spec:
+      domain:
+        cpu:
+          cores: 2
+        resources:
+          requests:
+            memory: 4Gi
+        devices:
+          disks:
+            - name: containerdisk
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              masquerade: {}
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          # Placeholder tag -- IMAGE_CONTAINERDISK_URI in the Makefile is
+          # the source of truth for where this actually gets published.
+          containerDisk:
+            image: quay.io/redhat-et/tank-os-containerdisk:latest
+        # Index 1 in this list -- deploy/applicationset.yaml's JSON6902
+        # patch addresses this volume's userData by that fixed index, so
+        # keep cloudinitdisk here (position 1) if this file changes.
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            # Same shape as examples/cloud-init/openclaw-user-data.yaml
+            # (shared SSH key, same openclaw user block) with a hostname
+            # key added -- REPLACE_WITH_YOUR_PUBLIC_KEY still needs a real
+            # key before this is usable; see docs/openshift-virtualization.md.
+            userData: |
+              #cloud-config
+              hostname: tank-USER_PLACEHOLDER
+              users:
+                - name: openclaw
+                  gecos: OpenClaw
+                  groups:
+                    - wheel
+                  sudo:
+                    - ALL=(ALL) NOPASSWD:ALL
+                  shell: /bin/bash
+                  lock_passwd: true
+                  ssh_authorized_keys:
+                    - ssh-ed25519 REPLACE_WITH_YOUR_PUBLIC_KEY tank-os
+              runcmd:
+                - [loginctl, enable-linger, openclaw]

--- a/deploy/base/virtualmachine.yaml
+++ b/deploy/base/virtualmachine.yaml
@@ -10,7 +10,7 @@ metadata:
     app: tank-os
     tank-os/user: USER_PLACEHOLDER
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       labels:

--- a/deploy/containerdisk/Containerfile
+++ b/deploy/containerdisk/Containerfile
@@ -4,8 +4,10 @@
 # virt-handler extracts it directly from the image layers at VM start; it
 # never runs this image as a container.
 #
-# Build context must be the directory containing disk.qcow2 (typically
-# out-tank-os/qcow2/) -- see the `build-containerdisk` Makefile target.
+# Build context must be the directory containing disk.qcow2 -- the
+# `build-containerdisk` Makefile target copies it here (from
+# out-tank-os/qcow2/) and uses this directory (deploy/containerdisk/) as
+# the build context, not out-tank-os/qcow2/ itself.
 
 FROM scratch
 COPY disk.qcow2 /disk/

--- a/deploy/containerdisk/Containerfile
+++ b/deploy/containerdisk/Containerfile
@@ -1,0 +1,11 @@
+# Wraps a tank-os qcow2 disk (from `make build-qcow2`) as a KubeVirt
+# containerDisk -- the standard convention KubeVirt's own docs describe:
+# an otherwise-empty image with the disk file at /disk/. KubeVirt's
+# virt-handler extracts it directly from the image layers at VM start; it
+# never runs this image as a container.
+#
+# Build context must be the directory containing disk.qcow2 (typically
+# out-tank-os/qcow2/) -- see the `build-containerdisk` Makefile target.
+
+FROM scratch
+COPY disk.qcow2 /disk/

--- a/docs/openshift-virtualization.md
+++ b/docs/openshift-virtualization.md
@@ -86,8 +86,20 @@ make build IMAGE_REGISTRY=quay.io IMAGE_NAMESPACE=redhat-et     # tags quay.io/r
 make push IMAGE_REGISTRY=quay.io IMAGE_NAMESPACE=redhat-et      # publishes the bootc image itself
 make build-qcow2 IMAGE_REGISTRY=quay.io IMAGE_NAMESPACE=redhat-et   # produces out-tank-os/qcow2/disk.qcow2
 make build-containerdisk         # wraps it (needs the qcow2 above first)
-make push-containerdisk
+make push-containerdisk-arch     # pushes under :$(ARCH), NOT plain :latest -- see below
 ```
+
+The example above targets `quay.io/redhat-et` — the real shared namespace
+these images are published under — so it deliberately uses
+`push-containerdisk-arch` rather than plain `push-containerdisk`:
+`quay.io/redhat-et/tank-os-containerdisk:latest` is a real multi-arch
+manifest list, and pushing a single-arch build straight to that tag would
+silently replace it, breaking every other architecture's pull. Finish the
+publish with the manifest-merge steps in "Publishing a multi-arch
+containerdisk" below. If you're instead pushing to your own personal
+`IMAGE_REGISTRY`/`IMAGE_NAMESPACE` override with no existing multi-arch
+manifest to protect, plain `make push-containerdisk` (straight to
+`:latest`) is simpler and fine.
 
 All three registry repos (`tank-os`, `tank-claw-openshell`,
 `tank-os-containerdisk`) already exist under `quay.io/redhat-et` with
@@ -154,9 +166,12 @@ kustomize build deploy/base                    # confirms the base renders as va
 oc apply --dry-run=client -f deploy/applicationset.yaml   # confirms the ApplicationSet YAML itself is well-formed
 ```
 
-Full KubeVirt CRD schema validation (confirming `VirtualMachine`'s fields
-are actually valid per the CRD, not just valid YAML) needs a live cluster
-with the KubeVirt CRDs installed — not attempted here.
+These two commands are what's checkable *without* a live cluster (`oc
+apply --dry-run=client` only validates well-formed YAML, not the actual
+`VirtualMachine` CRD schema). Full CRD schema validation needed a real
+cluster with KubeVirt installed — that gap is closed; see "First real
+cluster test" below for the live `oc apply --dry-run=server` and full
+deploy results.
 
 The JSON6902 patch in `applicationset.yaml` was verified by hand: copied
 `deploy/base/virtualmachine.yaml` into a scratch directory, wrote the same

--- a/docs/openshift-virtualization.md
+++ b/docs/openshift-virtualization.md
@@ -4,19 +4,17 @@ This packages tank-os as a KubeVirt `containerDisk` and automates
 per-user VM provisioning via ArgoCD, so onboarding a user means adding
 one line to a list, not manually creating a VM.
 
-**Status: confirmed working on a live OpenShift Virtualization cluster**
-(OpenShift Virtualization 4.21.13, 2026-07-29) — a `VirtualMachine` applied
-directly from `deploy/base/` (not yet through the ArgoCD `ApplicationSet`;
-see "Still open" below) reached `Running`, cloud-init applied the injected
-SSH key and hostname, and the OpenClaw/OpenShell bootstrap sequence came up
-the same way it does under QEMU/Lima. Two real bugs turned up and are fixed
-as of this test — see "What broke on a real cluster" below.
-
-**Still open:** the ArgoCD `ApplicationSet` itself (`deploy/applicationset.yaml`)
-has only been validated locally (`kustomize build`, manual patch-rendering
-simulation) — the direct-`oc apply` smoke test validates the `VirtualMachine`
-manifest and images, not ArgoCD's own Go-template rendering or the
-per-namespace GitOps flow. See "First real cluster test" for what's left.
+**Status: confirmed working end to end on a live OpenShift Virtualization
+cluster** (OpenShift Virtualization 4.21.13, 2026-07-29), including the
+full ArgoCD `ApplicationSet` path — not just a direct `oc apply` of the
+`VirtualMachine` manifest. `oc apply -f deploy/applicationset.yaml`
+generated per-user `Application`s, each with its own namespace and a
+`Running`/`Ready` VM; cloud-init applied the injected SSH key and hostname
+correctly for each user; and the OpenClaw/OpenShell bootstrap sequence came
+up the same way it does under QEMU/Lima. Three real bugs turned up during
+this testing and are fixed as of this doc — see "What broke on a real
+cluster" and "First real cluster test" below for what was found and what's
+still an open, documented gap (namespace cleanup on user removal).
 
 ## What broke on a real cluster (and is now fixed)
 
@@ -100,6 +98,36 @@ from local Podman storage via `--local`), but it's what makes
 VMs (see `docs/build.md`'s "Upgrade A Running VM"), and lets this whole
 pipeline be reproduced from a different machine or CI runner instead of
 requiring the exact local build state.
+
+### Publishing a multi-arch containerdisk
+
+All three published tags are real multi-arch manifest lists (see "What
+broke on a real cluster" below for why this matters) — `make
+push-containerdisk` as shown above only pushes whatever single
+architecture you built locally, and pushing that straight to `:latest`
+would silently replace the manifest list with a single-arch image
+(`make` prints a warning at that exact point). To publish a genuine
+update covering both architectures, build each on its own native host
+(cross-arch emulation works but is slow) and merge them:
+
+```bash
+# On an arm64 host:
+make build-containerdisk push-containerdisk-arch   # pushes :$(ARCH), i.e. :arm64
+
+# On an amd64 host:
+make build-containerdisk push-containerdisk-arch   # pushes :amd64
+
+# From either host, once both arch tags exist in the registry:
+podman manifest create quay.io/redhat-et/tank-os-containerdisk:latest \
+  docker://quay.io/redhat-et/tank-os-containerdisk:arm64 \
+  docker://quay.io/redhat-et/tank-os-containerdisk:amd64
+podman manifest push --all quay.io/redhat-et/tank-os-containerdisk:latest \
+  docker://quay.io/redhat-et/tank-os-containerdisk:latest
+```
+
+This is exactly the procedure used to fix the multi-arch bug below —
+confirmed working by rebuilding on a native x86_64 host and merging with
+the existing arm64 image.
 
 ## Adding a user
 

--- a/docs/openshift-virtualization.md
+++ b/docs/openshift-virtualization.md
@@ -4,17 +4,60 @@ This packages tank-os as a KubeVirt `containerDisk` and automates
 per-user VM provisioning via ArgoCD, so onboarding a user means adding
 one line to a list, not manually creating a VM.
 
-**Status: images published, not yet deployed against a live cluster.**
-`quay.io/redhat-et/tank-os`, `tank-claw-openshell`, and
-`tank-os-containerdisk` are all built and pushed (public read, confirmed
-via anonymous pull). No OpenShift Virtualization (CNV)-capable cluster
-with bare-metal nodes was available while writing this (same gap as the
-original smoke test — see `tank-os-smoke-test-summary.md`), so the
-`deploy/` manifests themselves have only been validated locally
-(`kustomize build`, manual patch-rendering simulation, `oc apply
---dry-run=client`), not against a real ArgoCD/KubeVirt install. See "First
-real cluster test" at the end for what to run the moment cluster access
-exists.
+**Status: confirmed working on a live OpenShift Virtualization cluster**
+(OpenShift Virtualization 4.21.13, 2026-07-29) — a `VirtualMachine` applied
+directly from `deploy/base/` (not yet through the ArgoCD `ApplicationSet`;
+see "Still open" below) reached `Running`, cloud-init applied the injected
+SSH key and hostname, and the OpenClaw/OpenShell bootstrap sequence came up
+the same way it does under QEMU/Lima. Two real bugs turned up and are fixed
+as of this test — see "What broke on a real cluster" below.
+
+**Still open:** the ArgoCD `ApplicationSet` itself (`deploy/applicationset.yaml`)
+has only been validated locally (`kustomize build`, manual patch-rendering
+simulation) — the direct-`oc apply` smoke test validates the `VirtualMachine`
+manifest and images, not ArgoCD's own Go-template rendering or the
+per-namespace GitOps flow. See "First real cluster test" for what's left.
+
+## What broke on a real cluster (and is now fixed)
+
+- **The published images were arm64-only, not actually multi-arch.**
+  `quay.io/redhat-et/{tank-os,tank-claw-openshell,tank-os-containerdisk}`
+  had all been built from an Apple Silicon Mac and pushed as plain
+  single-architecture images — nothing checked this against a real amd64
+  target until this cluster test failed with the VM's guest network never
+  coming up (`no route to host` dialing the SSH port; the guest OS never
+  actually booted because an aarch64 kernel/bootloader can't run under an
+  x86_64 KVM domain, which is what KubeVirt configures on this cluster's
+  amd64 nodes). Fixed by building genuine amd64 variants of all three
+  images on a native x86_64 host and merging them with the existing arm64
+  images into real multi-arch manifest lists (`podman manifest
+  create`/`push --all`) under the same tags — `docker`/`podman`/KubeVirt
+  now all pull the architecture that matches the node automatically. No
+  arch-specific tags needed going forward; keep pushing both architectures
+  under the same tag when either image changes.
+- **`spec.running: true` is deprecated** in this cluster's KubeVirt version
+  (`spec.runStrategy: Always` is the replacement) — `oc apply` warned but
+  didn't fail. Fixed in `deploy/base/virtualmachine.yaml`; confirmed via
+  `oc apply --dry-run=server` that `runStrategy: Always` validates with no
+  warning against the real CRD.
+
+## Connecting to a VM's SSH port
+
+Nothing in this doc previously said *how* to actually reach a VM's SSH
+port from outside the cluster — `ssh openclaw@<pod-ip>` doesn't work here,
+the VM's pod-network IP isn't routable from your workstation. Use
+`virtctl port-forward` (from the `virtctl` CLI, downloadable via
+`oc get consoleclidownload virtctl-clidownloads-kubevirt-hyperconverged
+-o jsonpath='{.spec.links[*].href}'` for a build matching your OS/arch):
+
+```bash
+virtctl port-forward -n <namespace> vmi/<vm-name> 2222:22 &
+ssh -p 2222 openclaw@localhost
+```
+
+`oc port-forward` does **not** work against a `VirtualMachineInstance`
+directly (`oc`'s client-go scheme doesn't know the `kubevirt.io/v1` types) —
+this has to be `virtctl`, not plain `oc`/`kubectl`.
 
 ## Architecture
 
@@ -98,26 +141,44 @@ are sound.
 
 ## First real cluster test
 
-Once a CNV-capable cluster (OpenShift Virtualization operator installed,
-bare-metal-capable nodes) is available:
+Confirmed so far, on a live OpenShift Virtualization 4.21.13 cluster
+(2026-07-29):
 
-1. Confirm OpenShift GitOps (ArgoCD) is installed:
-   `oc get csv -n openshift-gitops-operator`.
+- [x] Cluster has the KubeVirt CRDs, a `HyperConverged` CR, and schedulable
+  nodes (`oc get hyperconverged -A`, `oc get nodes -l
+  kubevirt.io/schedulable=true`) — all present and healthy.
+- [x] `deploy/base/virtualmachine.yaml` applied directly (`oc apply`, real
+  SSH key and namespace substituted for the placeholders) reaches
+  `Running`/`Ready` against the real `VirtualMachine` CRD.
+- [x] cloud-init applies the injected SSH key and `hostname:` correctly;
+  `virtctl port-forward` + `ssh` confirms connectivity (see "Connecting to
+  a VM's SSH port" above).
+- [x] OpenClaw/OpenShell bootstrap sequence (`bootstrap-openclaw` →
+  `bootstrap-openshell-sandbox`) comes up the same way as under QEMU/Lima.
+- [x] Multi-arch images (both fixes above) — confirmed by rebuilding amd64
+  variants on a native x86_64 host and re-testing after the manifest-list
+  fix.
+
+Still to do — the ArgoCD `ApplicationSet` path itself:
+
+1. Confirm OpenShift GitOps (ArgoCD) is installed: `oc get csv -A | grep -i
+   gitops` (namespace varies by install — don't hardcode
+   `openshift-gitops-operator`, check for it).
 2. Replace `REPLACE_WITH_YOUR_PUBLIC_KEY` in
    `deploy/applicationset.yaml`'s patch (and in `deploy/base/virtualmachine.yaml`,
    used only if the patch doesn't apply for some element) with a real key.
-3. Build, publish, and confirm the containerDisk pulls:
-   `make build-qcow2 build-containerdisk push-containerdisk`, then
-   `podman pull $(IMAGE_CONTAINERDISK_URI):latest` from a clean environment
-   to confirm public read access.
+3. Update `deploy/applicationset.yaml`'s `repoURL`/`targetRevision` to
+   point at wherever these manifests actually live (currently `main` on
+   `LobsterTrap/tank-os.git`, which won't have `deploy/` until this PR
+   merges) — or target this branch directly for a pre-merge test.
 4. `oc apply -f deploy/applicationset.yaml` and watch
    `oc get applications -n openshift-gitops` for sync health.
 5. Confirm the namespaces (`tank-alice`, `tank-bob`, ...) were created
    and each has a `VirtualMachine`/`VirtualMachineInstance` reaching
    `Running`.
-6. SSH into one VM and confirm `hostname` matches
-   (`tank-alice`, not `tank`) and OpenClaw/OpenShell come up the same way
-   verified in `docs/openshell.md`'s manual test.
+6. SSH into one VM (via `virtctl port-forward`, see above) and confirm
+   `hostname` matches (`tank-alice`, not `tank`) and OpenClaw/OpenShell
+   come up the same way verified in `docs/openshell.md`'s manual test.
 7. Edit the `ApplicationSet` to add a throwaway test user, confirm ArgoCD
    creates the new `Application`/namespace/VM without touching the
    existing ones, then remove it again to confirm cleanup

--- a/docs/openshift-virtualization.md
+++ b/docs/openshift-virtualization.md
@@ -159,28 +159,56 @@ Confirmed so far, on a live OpenShift Virtualization 4.21.13 cluster
   variants on a native x86_64 host and re-testing after the manifest-list
   fix.
 
-Still to do — the ArgoCD `ApplicationSet` path itself:
+The ArgoCD `ApplicationSet` path itself is now also confirmed, same
+cluster and session:
 
-1. Confirm OpenShift GitOps (ArgoCD) is installed: `oc get csv -A | grep -i
-   gitops` (namespace varies by install — don't hardcode
-   `openshift-gitops-operator`, check for it).
-2. Replace `REPLACE_WITH_YOUR_PUBLIC_KEY` in
-   `deploy/applicationset.yaml`'s patch (and in `deploy/base/virtualmachine.yaml`,
-   used only if the patch doesn't apply for some element) with a real key.
-3. Update `deploy/applicationset.yaml`'s `repoURL`/`targetRevision` to
-   point at wherever these manifests actually live (currently `main` on
-   `LobsterTrap/tank-os.git`, which won't have `deploy/` until this PR
-   merges) — or target this branch directly for a pre-merge test.
-4. `oc apply -f deploy/applicationset.yaml` and watch
-   `oc get applications -n openshift-gitops` for sync health.
-5. Confirm the namespaces (`tank-alice`, `tank-bob`, ...) were created
-   and each has a `VirtualMachine`/`VirtualMachineInstance` reaching
-   `Running`.
-6. SSH into one VM (via `virtctl port-forward`, see above) and confirm
-   `hostname` matches (`tank-alice`, not `tank`) and OpenClaw/OpenShell
-   come up the same way verified in `docs/openshell.md`'s manual test.
-7. Edit the `ApplicationSet` to add a throwaway test user, confirm ArgoCD
-   creates the new `Application`/namespace/VM without touching the
-   existing ones, then remove it again to confirm cleanup
-   (`prune: true` should delete the namespace's resources — verify it
-   doesn't orphan anything).
+- [x] OpenShift GitOps was already installed on this cluster
+  (`oc get pods -n openshift-gitops` showed a healthy ArgoCD install; the
+  operator's CSV turned up in `openshift-virtualization-os-images`, not
+  the `openshift-gitops-operator` namespace the original checklist
+  guessed — namespace really does vary by install, don't hardcode it).
+- [x] `oc apply -f deploy/applicationset.yaml` (real key substituted,
+  `targetRevision` pointed at this branch pre-merge) generated
+  `tank-os-alice`/`tank-os-bob` `Application`s, each creating its own
+  namespace and a `VirtualMachine` reaching `Running`/`Ready`.
+- [x] SSH into both (`virtctl port-forward`) confirmed `hostname` is
+  `tank-alice`/`tank-bob` respectively, not `tank` — the JSON6902 patch's
+  per-user substitution is correct end to end through ArgoCD's own
+  Go-template rendering, not just the manual dry-run simulation done
+  earlier.
+- [x] Adding a throwaway `carol` entry to the List generator: ArgoCD
+  created `tank-os-carol`/namespace `tank-carol`/VM `tank-carol` without
+  touching `alice`/`bob`.
+- [x] Removing `carol` again: ArgoCD pruned the `Application` and
+  everything it tracked inside `tank-carol` (the VM, etc.) — see the bug
+  and the known gap below for what this step actually surfaced.
+
+**Bug found and fixed: `goTemplate: true` is required.** The manifest
+uses dot-prefixed Go-template syntax (`{{.user}}`) throughout, but this
+cluster's ApplicationSet controller doesn't default to that engine —
+without `spec.goTemplate: true`, it falls back to a legacy templating mode
+that doesn't recognize `{{.user}}` at all and renders it as literal text.
+Every generated `Application` then got the identical literal name
+`tank-os-{{.user}}`, which ArgoCD rejected outright: `ApplicationSet
+tank-os contains applications with duplicate name: tank-os-{{.user}}`.
+Fixed by adding `goTemplate: true` (plus the recommended
+`goTemplateOptions: ["missingkey=error"]`, so a real typo in a template
+key fails loudly instead of silently rendering `<no value>`).
+
+**Known gap, not yet fixed: removing a user leaves an empty namespace
+behind.** After pruning `carol`'s `Application`, `tank-carol` the
+*namespace* stayed `Active` with zero resources in it — confirmed it
+wasn't just mid-termination (checked again after 20+ seconds, still
+`Active`). This is standard ArgoCD behavior, not a misconfiguration:
+`CreateNamespace=true` is a sync-time side effect, not a resource ArgoCD
+tracks and therefore not something `prune: true` cleans up. Cleaned it up
+manually (`oc delete namespace tank-carol`) for this test. Removing users
+at any real scale will accumulate empty leftover namespaces unless this
+gets addressed — options worth evaluating later: an ArgoCD
+`PreDelete`/`resource-hook`-based cleanup Job, a periodic sweep for
+empty `tank-*` namespaces, or declaring the `Namespace` object as an
+actual tracked resource in `deploy/base/` instead of relying on
+`CreateNamespace=true` (trades one problem for needing per-user
+Kustomize overlays instead of a single shared base, which is exactly the
+"N checked-in files" this architecture was designed to avoid — not a
+clear win, worth thinking through rather than doing reflexively).

--- a/docs/openshift-virtualization.md
+++ b/docs/openshift-virtualization.md
@@ -4,11 +4,14 @@ This packages tank-os as a KubeVirt `containerDisk` and automates
 per-user VM provisioning via ArgoCD, so onboarding a user means adding
 one line to a list, not manually creating a VM.
 
-**Status: authored, not yet deployed against a live cluster.** No
-OpenShift Virtualization (CNV)-capable cluster with bare-metal nodes was
-available while writing this (same gap as the original smoke test — see
-`tank-os-smoke-test-summary.md`). Everything below has been validated
-locally (`kustomize build`, manual patch-rendering simulation, `oc apply
+**Status: images published, not yet deployed against a live cluster.**
+`quay.io/redhat-et/tank-os`, `tank-claw-openshell`, and
+`tank-os-containerdisk` are all built and pushed (public read, confirmed
+via anonymous pull). No OpenShift Virtualization (CNV)-capable cluster
+with bare-metal nodes was available while writing this (same gap as the
+original smoke test — see `tank-os-smoke-test-summary.md`), so the
+`deploy/` manifests themselves have only been validated locally
+(`kustomize build`, manual patch-rendering simulation, `oc apply
 --dry-run=client`), not against a real ArgoCD/KubeVirt install. See "First
 real cluster test" at the end for what to run the moment cluster access
 exists.
@@ -38,15 +41,22 @@ user, so per-VM values can only be injected at deploy time.
 ## Building and publishing the containerDisk
 
 ```bash
-make build-qcow2                 # produces out-tank-os/qcow2/disk.qcow2
+make build IMAGE_REGISTRY=quay.io IMAGE_NAMESPACE=redhat-et     # tags quay.io/redhat-et/tank-os:latest
+make push IMAGE_REGISTRY=quay.io IMAGE_NAMESPACE=redhat-et      # publishes the bootc image itself
+make build-qcow2 IMAGE_REGISTRY=quay.io IMAGE_NAMESPACE=redhat-et   # produces out-tank-os/qcow2/disk.qcow2
 make build-containerdisk         # wraps it (needs the qcow2 above first)
-make push-containerdisk          # needs IMAGE_CONTAINERDISK_URI to actually exist as a repo
+make push-containerdisk
 ```
 
-`IMAGE_CONTAINERDISK_URI` defaults to `quay.io/redhat-et/tank-os-containerdisk`
-— that repo doesn't exist yet. Create it the same way as
-`tank-claw-openshell` earlier (public read, robot account push) before
-running `push-containerdisk` for real.
+All three registry repos (`tank-os`, `tank-claw-openshell`,
+`tank-os-containerdisk`) already exist under `quay.io/redhat-et` with
+public read and robot-account push access. Publishing the bootc `tank-os`
+image itself isn't required for `build-qcow2` to work (that target reads
+from local Podman storage via `--local`), but it's what makes
+`bootc switch`/`bootc upgrade` in-place updates possible on already-running
+VMs (see `docs/build.md`'s "Upgrade A Running VM"), and lets this whole
+pipeline be reproduced from a different machine or CI runner instead of
+requiring the exact local build state.
 
 ## Adding a user
 

--- a/docs/openshift-virtualization.md
+++ b/docs/openshift-virtualization.md
@@ -1,0 +1,115 @@
+# OpenShift Virtualization: per-user provisioning
+
+This packages tank-os as a KubeVirt `containerDisk` and automates
+per-user VM provisioning via ArgoCD, so onboarding a user means adding
+one line to a list, not manually creating a VM.
+
+**Status: authored, not yet deployed against a live cluster.** No
+OpenShift Virtualization (CNV)-capable cluster with bare-metal nodes was
+available while writing this (same gap as the original smoke test — see
+`tank-os-smoke-test-summary.md`). Everything below has been validated
+locally (`kustomize build`, manual patch-rendering simulation, `oc apply
+--dry-run=client`), not against a real ArgoCD/KubeVirt install. See "First
+real cluster test" at the end for what to run the moment cluster access
+exists.
+
+## Architecture
+
+One shared `containerDisk` image, N cheap ArgoCD `Application`s — not N
+built images and not N checked-in VM manifests:
+
+| Piece | What it does |
+| --- | --- |
+| `deploy/containerdisk/Containerfile` | Wraps `make build-qcow2`'s output (`FROM scratch` + `COPY disk.qcow2 /disk/`), KubeVirt's documented convention. One image, referenced by every VM. |
+| `deploy/base/virtualmachine.yaml` | A single KubeVirt `VirtualMachine` template with placeholder tokens (`USER_PLACEHOLDER`) for name/labels/hostname. |
+| `deploy/applicationset.yaml` | An ArgoCD `ApplicationSet` with a **List generator** — one entry per user. Each generates an `Application` pointing at `deploy/base/`, patched per user via a JSON6902 Kustomize patch. |
+
+Per-user customization (hostname + VM name/labels) lives entirely in the
+`ApplicationSet`'s list — adding a user is a one-line diff, not a new
+file or directory. Per the confirmed decisions for this phase: SSH key,
+OpenClaw config, and storage/resource sizing are **identical across all
+users**, so there's nothing else to parameterize yet.
+
+Hostname is set via `cloudInitNoCloud.userData` (cloud-init's
+`set_hostname` module, already confirmed enabled by default in this
+image), not baked into the containerDisk — the same image serves every
+user, so per-VM values can only be injected at deploy time.
+
+## Building and publishing the containerDisk
+
+```bash
+make build-qcow2                 # produces out-tank-os/qcow2/disk.qcow2
+make build-containerdisk         # wraps it (needs the qcow2 above first)
+make push-containerdisk          # needs IMAGE_CONTAINERDISK_URI to actually exist as a repo
+```
+
+`IMAGE_CONTAINERDISK_URI` defaults to `quay.io/redhat-et/tank-os-containerdisk`
+— that repo doesn't exist yet. Create it the same way as
+`tank-claw-openshell` earlier (public read, robot account push) before
+running `push-containerdisk` for real.
+
+## Adding a user
+
+Edit `deploy/applicationset.yaml`'s List generator:
+
+```yaml
+generators:
+  - list:
+      elements:
+        - user: alice
+        - user: bob
+        - user: carol   # <- add this line
+```
+
+ArgoCD picks up the new entry on its next generator refresh and creates
+`tank-os-carol` (an `Application`) → namespace `tank-carol` → a
+`VirtualMachine` named `tank-carol` with hostname `tank-carol`. Nothing
+else needs to change.
+
+## Local validation
+
+```bash
+kustomize build deploy/base                    # confirms the base renders as valid YAML
+oc apply --dry-run=client -f deploy/applicationset.yaml   # confirms the ApplicationSet YAML itself is well-formed
+```
+
+Full KubeVirt CRD schema validation (confirming `VirtualMachine`'s fields
+are actually valid per the CRD, not just valid YAML) needs a live cluster
+with the KubeVirt CRDs installed — not attempted here.
+
+The JSON6902 patch in `applicationset.yaml` was verified by hand: copied
+`deploy/base/virtualmachine.yaml` into a scratch directory, wrote the same
+patch with `{{.user}}` manually substituted for `alice`, and confirmed
+`kustomize build` renders `metadata.name: tank-alice`, both
+`tank-os/user: alice` label locations, and `hostname: tank-alice` inside
+`userData` correctly. This isn't the same as ArgoCD's own Go-template
+rendering running for real, but it confirms the Kustomize patch mechanics
+are sound.
+
+## First real cluster test
+
+Once a CNV-capable cluster (OpenShift Virtualization operator installed,
+bare-metal-capable nodes) is available:
+
+1. Confirm OpenShift GitOps (ArgoCD) is installed:
+   `oc get csv -n openshift-gitops-operator`.
+2. Replace `REPLACE_WITH_YOUR_PUBLIC_KEY` in
+   `deploy/applicationset.yaml`'s patch (and in `deploy/base/virtualmachine.yaml`,
+   used only if the patch doesn't apply for some element) with a real key.
+3. Build, publish, and confirm the containerDisk pulls:
+   `make build-qcow2 build-containerdisk push-containerdisk`, then
+   `podman pull $(IMAGE_CONTAINERDISK_URI):latest` from a clean environment
+   to confirm public read access.
+4. `oc apply -f deploy/applicationset.yaml` and watch
+   `oc get applications -n openshift-gitops` for sync health.
+5. Confirm the namespaces (`tank-alice`, `tank-bob`, ...) were created
+   and each has a `VirtualMachine`/`VirtualMachineInstance` reaching
+   `Running`.
+6. SSH into one VM and confirm `hostname` matches
+   (`tank-alice`, not `tank`) and OpenClaw/OpenShell come up the same way
+   verified in `docs/openshell.md`'s manual test.
+7. Edit the `ApplicationSet` to add a throwaway test user, confirm ArgoCD
+   creates the new `Application`/namespace/VM without touching the
+   existing ones, then remove it again to confirm cleanup
+   (`prune: true` should delete the namespace's resources — verify it
+   doesn't orphan anything).

--- a/docs/quickstart-prebuilt.md
+++ b/docs/quickstart-prebuilt.md
@@ -147,25 +147,55 @@ Reboots into tank-os in place. Future updates: `sudo bootc upgrade --apply`.
 
 **Not yet a bootc host** (e.g. a regular Fedora Workstation/Server, or an
 empty VM) — boot the extracted qcow2 directly with `virt-install`, which
-Fedora ships by default:
+Fedora/RHEL ship by default:
 
 ```bash
-sudo virt-install \
+virt-install \
+  --connect qemu:///session \
   --name tank-os \
   --memory 4096 \
   --vcpus 2 \
   --disk ./tank-os-disk.qcow2,format=qcow2,bus=virtio \
   --import \
   --os-variant fedora-unknown \
-  --network network=default \
+  --network user,backend.type=passt,portForward0.proto=tcp,portForward0.range0.start=2222,portForward0.range0.to=22 \
   --graphics none \
-  --console pty,target_type=serial
+  --console pty,target_type=serial \
+  --cloud-init user-data=./user-data,meta-data=./meta-data \
+  --noautoconsole
 ```
+
+Verified on RHEL 10.2: `ssh -p 2222 openclaw@localhost` worked using a key
+from `--cloud-init` that was never baked into the image, and `virsh
+--connect qemu:///session console tank-os` attaches to the serial console.
+
+Two things this fixes that the obvious version of this command gets wrong:
+
+- **`--connect qemu:///session` instead of `sudo` + the default
+  `qemu:///system`.** With `qemu:///system`, libvirt runs QEMU as the
+  unprivileged system `qemu` user, which can't read a disk image anywhere
+  under your home directory if it's mode `700` (RHEL's default) — you'd
+  hit `Cannot access ... Permission denied` regardless of the disk's own
+  file permissions, since the *directory* itself blocks traversal.
+  `qemu:///session` runs QEMU as your own user instead, sidestepping the
+  problem entirely — no `sudo`, no moving the disk into
+  `/var/lib/libvirt/images/`.
+- **`--network user,backend.type=passt,portForward0...` instead of
+  `--network network=default`.** `network=default` is a system-level
+  virtual network only available under `qemu:///system` — under
+  `qemu:///session` there's no bridge to attach to, so it fails
+  immediately. `backend.type=passt` (the `passt` package; usually
+  preinstalled) plus explicit `portForward0.*` options gives usermode
+  networking with host port forwarding, the session-mode equivalent of
+  raw QEMU's `-netdev user,hostfwd=...`.
 
 Or use the repo's portable QEMU script (`examples/boot-tank-os-qemu.sh`) the
 same way `docs/build.md`'s "Launch on Linux (QEMU)" section describes, again
 pointing it at `./tank-os-disk.qcow2` instead of a fresh
-`out-tank-os/qcow2/disk.qcow2`.
+`out-tank-os/qcow2/disk.qcow2` — confirmed working as-is on RHEL 10.2,
+auto-detecting both `/usr/libexec/qemu-kvm` (RHEL has no separate
+`qemu-system-x86_64` binary) and `/usr/share/edk2/ovmf` (RHEL's OVMF path)
+with no manual `QEMU_BIN`/`OVMF_CODE` overrides needed.
 
 ## Lima (macOS/Linux)
 

--- a/docs/quickstart-prebuilt.md
+++ b/docs/quickstart-prebuilt.md
@@ -31,10 +31,74 @@ Linux hosts directly. For x86_64, either build locally
 images to also push an amd64-tagged containerdisk; a single tag can only hold
 one architecture's disk.
 
-The SSH keys and OpenClaw/OpenShell config already baked into `tank-os:latest`
-came from whatever `config.toml` was used at containerdisk build time — check
-with whoever published it, or expect to need your own build if you need a
-different key.
+The SSH key already baked into the published qcow2 belongs to whoever built
+and pushed it — you almost certainly don't have that private key, so plain
+`ssh openclaw@...` against the shared image will just hang/refuse. See "Use
+your own SSH key" below before trying to connect.
+
+## Use your own SSH key instead of the baked-in one
+
+A shared, published disk image can only have one SSH key baked in at build
+time (via `config.toml`'s `[[customizations.user]]`, see `docs/build.md`) —
+fine for a private build, useless for anyone else pulling the same
+published image. The fix isn't to rebuild the image per person (that
+defeats the point of publishing one shared containerdisk); it's to inject
+your own key at **boot time** instead, via a small cloud-init NoCloud seed
+ISO attached alongside the disk. This is the same mechanism Lima uses to
+give every instance its own key without baking anything into its shared
+base images, and the same `cloudInitNoCloud` shape already used for
+per-user VMs in `deploy/base/virtualmachine.yaml`.
+
+Reuse this repo's existing cloud-config (already shaped for the pre-existing
+`openclaw` user — cloud-init adds your key to that user's
+`authorized_keys`, it doesn't need to recreate the user):
+
+```bash
+cp examples/cloud-init/openclaw-user-data.yaml ./user-data
+python3 -c "
+import pathlib
+key = pathlib.Path.home().joinpath('.ssh/id_ed25519.pub').read_text().strip()
+p = pathlib.Path('user-data')
+p.write_text(p.read_text().replace('ssh-ed25519 REPLACE_WITH_YOUR_PUBLIC_KEY tank-os', key))
+"
+
+cat > ./meta-data <<'EOF'
+instance-id: tank-os-quickstart
+local-hostname: tank
+EOF
+```
+
+Then build a `cidata`-labeled seed ISO from those two files — pick whichever
+tool you already have:
+
+```bash
+# Linux, if cloud-utils/cloud-image-utils is installed:
+cloud-localds seed.iso user-data meta-data
+
+# Linux or macOS, if genisoimage/mkisofs/cdrtools is installed:
+genisoimage -output seed.iso -volid cidata -joliet -rock user-data meta-data
+
+# macOS, no extra installs needed (built-in hdiutil):
+mkdir -p seed && cp user-data meta-data seed/
+hdiutil makehybrid -iso -joliet -default-volume-name cidata -o seed.iso seed
+```
+
+Then attach `seed.iso` as one more `-drive` in whichever QEMU invocation
+you're using below:
+
+```bash
+-drive file=seed.iso,format=raw,if=virtio
+```
+
+Verified end to end this way (macOS/aarch64, QEMU+HVF): SSH succeeded using
+a key that was never part of the image at all, added purely through the
+seed ISO — confirming this works regardless of whatever key the image's
+builder baked in.
+
+`virt-install` (Fedora Linux, below) has this built in — pass
+`--cloud-init user-data=./user-data,meta-data=./meta-data` instead of
+building the ISO by hand; virt-install generates the same kind of seed
+image itself.
 
 ## macOS (Apple Silicon) via QEMU
 
@@ -56,13 +120,16 @@ qemu-system-aarch64 \
   -drive file=./tank-os-disk.qcow2,format=qcow2,if=virtio \
   -drive if=pflash,format=raw,readonly=on,file="$qemu_share/edk2-aarch64-code.fd" \
   -drive if=pflash,format=raw,file=./edk2-arm-vars.fd \
+  -drive file=./seed.iso,format=raw,if=virtio \
   -device virtio-net-pci,netdev=net0 \
   -netdev user,id=net0,hostfwd=tcp::2222-:22 \
   -nographic
 ```
 
 Requires `brew install qemu`. SSH once booted: `ssh -p 2222 openclaw@localhost`
-(assuming the published image's baked-in key matches yours).
+using **your own key** from `seed.iso` above — drop the `-drive
+file=./seed.iso,...` line entirely if you already know the published
+image's baked-in key matches yours (e.g. you built it yourself).
 
 ## Fedora Linux
 

--- a/docs/quickstart-prebuilt.md
+++ b/docs/quickstart-prebuilt.md
@@ -1,0 +1,169 @@
+# Quick Start: Run tank-os From Published Images
+
+This is the "just run it" path — no `make build`, no bootc-image-builder
+invocation, no `config.toml`. Everything here pulls from the already-published
+images:
+
+| Image | Used for |
+| --- | --- |
+| `quay.io/redhat-et/tank-os-containerdisk:latest` | Contains a ready-to-boot `disk.qcow2` — extract it and boot with any hypervisor |
+| `quay.io/redhat-et/tank-os:latest` | The bootc OS image itself — only needed for `bootc switch`/`bootc upgrade` on an existing bootc host |
+
+All three published repos (`tank-os`, `tank-claw-openshell`,
+`tank-os-containerdisk`) are public-read; no `podman login` required to pull.
+
+## Extract the disk image
+
+The containerdisk image is a `FROM scratch` wrapper around one file
+(`/disk/disk.qcow2`, KubeVirt's convention) — `podman create` + `podman cp`
+pulls it out without running the container:
+
+```bash
+podman create --name tank-os-extract quay.io/redhat-et/tank-os-containerdisk:latest
+podman cp tank-os-extract:/disk/disk.qcow2 ./tank-os-disk.qcow2
+podman rm tank-os-extract
+```
+
+This qcow2 was built with `--rootfs xfs` for `arm64` (see the Makefile's
+`build-containerdisk` target) — it boots on Apple Silicon and on aarch64
+Linux hosts directly. For x86_64, either build locally
+(`make build-qcow2 ARCH=amd64`, see `docs/build.md`) or ask whoever publishes
+images to also push an amd64-tagged containerdisk; a single tag can only hold
+one architecture's disk.
+
+The SSH keys and OpenClaw/OpenShell config already baked into `tank-os:latest`
+came from whatever `config.toml` was used at containerdisk build time — check
+with whoever published it, or expect to need your own build if you need a
+different key.
+
+## macOS (Apple Silicon) via QEMU
+
+Same QEMU + HVF invocation as `docs/build.md`'s "Launch on macOS" section,
+just pointed at the extracted qcow2 instead of a locally built one:
+
+```bash
+qemu-img resize ./tank-os-disk.qcow2 20G
+
+qemu_share="$(brew --prefix qemu)/share/qemu"
+cp "$qemu_share/edk2-arm-vars.fd" ./edk2-arm-vars.fd
+
+qemu-system-aarch64 \
+  -M virt,highmem=on \
+  -accel hvf \
+  -cpu host \
+  -smp 2 \
+  -m 4096 \
+  -drive file=./tank-os-disk.qcow2,format=qcow2,if=virtio \
+  -drive if=pflash,format=raw,readonly=on,file="$qemu_share/edk2-aarch64-code.fd" \
+  -drive if=pflash,format=raw,file=./edk2-arm-vars.fd \
+  -device virtio-net-pci,netdev=net0 \
+  -netdev user,id=net0,hostfwd=tcp::2222-:22 \
+  -nographic
+```
+
+Requires `brew install qemu`. SSH once booted: `ssh -p 2222 openclaw@localhost`
+(assuming the published image's baked-in key matches yours).
+
+## Fedora Linux
+
+Two paths, depending on whether the target machine already runs a bootc-based
+OS:
+
+**Already on a bootc host** (e.g. a prior tank-os VM, or plain
+`fedora-bootc`) — no disk image needed at all, `bootc` handles the pull:
+
+```bash
+sudo bootc switch --apply quay.io/redhat-et/tank-os:latest
+```
+
+Reboots into tank-os in place. Future updates: `sudo bootc upgrade --apply`.
+
+**Not yet a bootc host** (e.g. a regular Fedora Workstation/Server, or an
+empty VM) — boot the extracted qcow2 directly with `virt-install`, which
+Fedora ships by default:
+
+```bash
+sudo virt-install \
+  --name tank-os \
+  --memory 4096 \
+  --vcpus 2 \
+  --disk ./tank-os-disk.qcow2,format=qcow2,bus=virtio \
+  --import \
+  --os-variant fedora-unknown \
+  --network network=default \
+  --graphics none \
+  --console pty,target_type=serial
+```
+
+Or use the repo's portable QEMU script (`examples/boot-tank-os-qemu.sh`) the
+same way `docs/build.md`'s "Launch on Linux (QEMU)" section describes, again
+pointing it at `./tank-os-disk.qcow2` instead of a fresh
+`out-tank-os/qcow2/disk.qcow2`.
+
+## Lima (macOS/Linux)
+
+**Confirmed working** on Lima 2.2.0 / macOS (Apple Silicon, M3), 2026-07-28,
+across all three of Lima's VM drivers. Ready-made manifests are at
+`examples/lima/`:
+
+| Manifest | Driver | Notes |
+| --- | --- | --- |
+| `tank-os-qemu.yaml` | QEMU | Works on macOS and Linux hosts alike; same HVF acceleration as the plain-QEMU recipe above |
+| `tank-os-vz.yaml` | Apple `Virtualization.framework` | macOS only, no firmware files to manage; networked over vsock instead of usermode NAT |
+| `tank-os-krunkit.yaml` | krunkit (libkrun) | macOS only; keeps the whole stack on the same hypervisor family this repo's own Podman-machine build path already uses |
+
+All three produced identical guest behavior (cloud-init, hostname,
+OpenClaw/OpenShell bring-up) — pick whichever driver is already installed;
+there's no functional reason to prefer one over another for this image.
+
+```bash
+mkdir -p ~/.lima/_images
+podman create --name tank-os-extract quay.io/redhat-et/tank-os-containerdisk:latest
+podman cp tank-os-extract:/disk/disk.qcow2 ~/.lima/_images/tank-os-disk.qcow2
+podman rm tank-os-extract
+
+limactl start --name tank-os ./examples/lima/tank-os-vz.yaml --tty=false
+limactl shell tank-os
+```
+
+(Swap in `tank-os-qemu.yaml` or `tank-os-krunkit.yaml` for a different
+driver — only `vmType` differs between the three files.)
+
+What actually happens, and what to expect:
+
+- **`limactl start` exits non-zero and prints "DEGRADED."** This is
+  harmless, not a failure to fix: Lima's health check requires its own
+  `lima-guestagent` to be running in the guest for port-forwarding/mount
+  status, and tank-os doesn't ship that agent. The VM itself boots and is
+  fully usable — `limactl list` shows `STATUS=Running`, and
+  `limactl shell tank-os` / plain `ssh` both work immediately. Ignore the
+  exit code and DEGRADED banner.
+- **Cloud-init runs cleanly and both cloud-init "layers" coexist.** Lima
+  injects its own NoCloud data (creating a `lima` user, its SSH key, and a
+  hostname) on top of tank-os's baked-in `cloud-init`/`sshd` — both apply
+  without conflict, confirming this base image needs no Lima-specific
+  changes to work as an "arbitrary" (non-Lima-aware) guest.
+- **Hostname becomes `lima-tank-os`, not `tank`.** Lima's own cloud-init
+  hostname module runs after tank-os's baked-in `/etc/hostname`
+  and wins — same "last cloud-init wins" behavior already documented for
+  the OpenShift Virtualization path's per-VM hostnames.
+- **One pre-existing, unrelated failed unit:** `cloud-init-main.service`
+  shows `failed` in `systemctl --failed` — this is Fedora's legacy
+  single-process cloud-init compatibility unit; the real boot-stage units
+  (`cloud-init-local`, `cloud-init-network`, `cloud-config`, `cloud-final`)
+  all report `active`/`exited` normally, so the system is functionally
+  fine despite `systemctl is-system-running` printing `degraded`.
+- **OpenClaw/OpenShell come up exactly as documented for QEMU.**
+  `openclaw.service` runs through the same `bootstrap-openclaw` →
+  `bootstrap-openshell-sandbox` sequence as `docs/openshell.md` describes,
+  including the known `openshell sandbox create` CLI-hang (the sandbox
+  reaches `Phase: Ready` well before the wrapping `timeout 600` process
+  exits) — this is the same pre-existing quirk on Lima as on bare QEMU, not
+  something Lima introduces.
+
+Verify from inside the guest:
+
+```bash
+limactl shell tank-os -- sudo -u openclaw \
+  env XDG_RUNTIME_DIR=/run/user/1000 openshell sandbox get tankos-openclaw
+```

--- a/docs/quickstart-prebuilt.md
+++ b/docs/quickstart-prebuilt.md
@@ -24,12 +24,18 @@ podman cp tank-os-extract:/disk/disk.qcow2 ./tank-os-disk.qcow2
 podman rm tank-os-extract
 ```
 
-This qcow2 was built with `--rootfs xfs` for `arm64` (see the Makefile's
-`build-containerdisk` target) — it boots on Apple Silicon and on aarch64
-Linux hosts directly. For x86_64, either build locally
-(`make build-qcow2 ARCH=amd64`, see `docs/build.md`) or ask whoever publishes
-images to also push an amd64-tagged containerdisk; a single tag can only hold
-one architecture's disk.
+All three published tags (`tank-os`, `tank-claw-openshell`,
+`tank-os-containerdisk`) are real multi-arch manifest lists covering both
+`arm64` and `amd64` — `podman pull`/`create` above automatically gets the
+disk matching whatever machine you run it on, no `ARCH=` flag or separate
+tag needed. (This wasn't always true: earlier in this repo's history these
+were single-arch images built only from an Apple Silicon Mac, which broke
+silently on amd64 targets — see `docs/openshift-virtualization.md`'s "What
+broke on a real cluster" for how that surfaced and got fixed. If you're
+publishing new versions of these images yourself, build and push both
+architectures and merge them with `podman manifest create`/`push --all`
+before publishing, or you'll reintroduce the same problem for the next
+architecture that isn't yours.)
 
 The SSH key already baked into the published qcow2 belongs to whoever built
 and pushed it — you almost certainly don't have that private key, so plain

--- a/docs/quickstart-prebuilt.md
+++ b/docs/quickstart-prebuilt.md
@@ -1,4 +1,4 @@
-# Quick Start: Run tank-os From Published Images
+# Quick start: run tank-os from published images
 
 This is the "just run it" path — no `make build`, no bootc-image-builder
 invocation, no `config.toml`. Everything here pulls from the already-published
@@ -19,7 +19,7 @@ The containerdisk image is a `FROM scratch` wrapper around one file
 pulls it out without running the container:
 
 ```bash
-podman create --name tank-os-extract quay.io/redhat-et/tank-os-containerdisk:latest
+podman create --replace --name tank-os-extract quay.io/redhat-et/tank-os-containerdisk:latest
 podman cp tank-os-extract:/disk/disk.qcow2 ./tank-os-disk.qcow2
 podman rm tank-os-extract
 ```
@@ -220,17 +220,18 @@ across all three of Lima's VM drivers. Ready-made manifests are at
 
 | Manifest | Driver | Notes |
 | --- | --- | --- |
-| `tank-os-qemu.yaml` | QEMU | Works on macOS and Linux hosts alike; same HVF acceleration as the plain-QEMU recipe above |
-| `tank-os-vz.yaml` | Apple `Virtualization.framework` | macOS only, no firmware files to manage; networked over vsock instead of usermode NAT |
-| `tank-os-krunkit.yaml` | krunkit (libkrun) | macOS only; keeps the whole stack on the same hypervisor family this repo's own Podman-machine build path already uses |
+| `tank-os-qemu.yaml` | QEMU | No `arch:` field — Lima defaults to the host's own architecture, and the containerdisk is a real multi-arch manifest, so this same config works unmodified on x86_64 Linux/macOS hosts too, not just Apple Silicon (only actually tested on aarch64 macOS so far — same HVF-equivalent acceleration path as the plain-QEMU recipe above) |
+| `tank-os-vz.yaml` | Apple `Virtualization.framework` | macOS Apple Silicon only (untested on Intel Macs) — no firmware files to manage; networked over vsock instead of usermode NAT |
+| `tank-os-krunkit.yaml` | krunkit (libkrun) | macOS Apple Silicon only (untested on Intel Macs) — keeps the whole stack on the same hypervisor family this repo's own Podman-machine build path already uses |
 
 All three produced identical guest behavior (cloud-init, hostname,
-OpenClaw/OpenShell bring-up) — pick whichever driver is already installed;
-there's no functional reason to prefer one over another for this image.
+OpenClaw/OpenShell bring-up) on the one configuration actually tested
+(aarch64 macOS) — pick whichever driver is already installed; there's no
+functional reason to prefer one over another for this image.
 
 ```bash
 mkdir -p ~/.lima/_images
-podman create --name tank-os-extract quay.io/redhat-et/tank-os-containerdisk:latest
+podman create --replace --name tank-os-extract quay.io/redhat-et/tank-os-containerdisk:latest
 podman cp tank-os-extract:/disk/disk.qcow2 ~/.lima/_images/tank-os-disk.qcow2
 podman rm tank-os-extract
 

--- a/docs/quickstart-prebuilt.md
+++ b/docs/quickstart-prebuilt.md
@@ -50,8 +50,17 @@ fine for a private build, useless for anyone else pulling the same
 published image. The fix isn't to rebuild the image per person (that
 defeats the point of publishing one shared containerdisk); it's to inject
 your own key at **boot time** instead, via a small cloud-init NoCloud seed
-ISO attached alongside the disk. This is the same mechanism Lima uses to
-give every instance its own key without baking anything into its shared
+ISO attached alongside the disk.
+
+Confirmed this holds even with **no baked-in key at all**: built a qcow2
+from a `config.toml` with an empty `[customizations]` block (no
+`[[customizations.user]]` entry, so `~openclaw/.ssh/authorized_keys` doesn't
+exist until cloud-init creates it) and deployed it on OpenShift
+Virtualization with only `deploy/base/virtualmachine.yaml`'s
+`cloudInitNoCloud` supplying a key — SSH worked immediately, same as every
+other test in this doc. The baked-in key was never load-bearing; cloud-init
+alone is sufficient. This is the same mechanism Lima uses to give every
+instance its own key without baking anything into its shared
 base images, and the same `cloudInitNoCloud` shape already used for
 per-user VMs in `deploy/base/virtualmachine.yaml`.
 

--- a/docs/quickstart-prebuilt.md
+++ b/docs/quickstart-prebuilt.md
@@ -240,7 +240,10 @@ limactl shell tank-os
 ```
 
 (Swap in `tank-os-qemu.yaml` or `tank-os-krunkit.yaml` for a different
-driver — only `vmType` differs between the three files.)
+driver. `tank-os-vz.yaml`/`tank-os-krunkit.yaml` also pin `arch: "aarch64"`
+explicitly, since both are Apple-Silicon-only anyway; `tank-os-qemu.yaml`
+leaves `arch` unset instead, since QEMU is the one driver here that's
+genuinely portable across host architectures — see the table above.)
 
 What actually happens, and what to expect:
 

--- a/examples/lima/tank-os-krunkit.yaml
+++ b/examples/lima/tank-os-krunkit.yaml
@@ -4,7 +4,11 @@
 # rootful-machine note), so this keeps the whole local stack on one
 # hypervisor family.
 # See tank-os-qemu.yaml for the image-extraction step and shared notes;
-# this file differs only in `vmType`.
+# this file differs in `vmType` and in pinning `arch: "aarch64"` explicitly
+# (tank-os-qemu.yaml leaves `arch` unset since it's the one driver here
+# that's genuinely portable across host architectures -- krunkit is
+# Apple-Silicon-only regardless, so pinning it here is just documentation,
+# not a behavior difference).
 #
 # Confirmed working on Lima 2.2.0 / macOS M3 (2026-07-28): identical guest
 # behavior to the qemu/vz variants (cloud-init, hostname, OpenClaw/OpenShell

--- a/examples/lima/tank-os-krunkit.yaml
+++ b/examples/lima/tank-os-krunkit.yaml
@@ -1,0 +1,26 @@
+# Lima config for booting tank-os using krunkit (libkrun) instead of QEMU --
+# macOS only. Notable because tank-os's own build/test infra already runs
+# atop a libkrun-backed Podman machine on macOS (see docs/build.md's
+# rootful-machine note), so this keeps the whole local stack on one
+# hypervisor family.
+# See tank-os-qemu.yaml for the image-extraction step and shared notes;
+# this file differs only in `vmType`.
+#
+# Confirmed working on Lima 2.2.0 / macOS M3 (2026-07-28): identical guest
+# behavior to the qemu/vz variants (cloud-init, hostname, OpenClaw/OpenShell
+# bring-up). Same expected "DEGRADED" exit from `limactl start` -- see
+# tank-os-qemu.yaml's comment and docs/quickstart-prebuilt.md.
+vmType: "krunkit"
+arch: "aarch64"
+images:
+  - location: "~/.lima/_images/tank-os-disk.qcow2"
+    arch: "aarch64"
+cpus: 2
+memory: "4GiB"
+disk: "20GiB"
+mounts: []
+containerd:
+  system: false
+  user: false
+ssh:
+  loadDotSSHPubKeys: true

--- a/examples/lima/tank-os-qemu.yaml
+++ b/examples/lima/tank-os-qemu.yaml
@@ -2,7 +2,7 @@
 # quay.io/redhat-et/tank-os-containerdisk, using Lima's QEMU driver
 # (works on both macOS and Linux hosts). Extract the qcow2 first:
 #
-#   podman create --name tank-os-extract quay.io/redhat-et/tank-os-containerdisk:latest
+#   podman create --replace --name tank-os-extract quay.io/redhat-et/tank-os-containerdisk:latest
 #   podman cp tank-os-extract:/disk/disk.qcow2 ~/.lima/_images/tank-os-disk.qcow2
 #   podman rm tank-os-extract
 #

--- a/examples/lima/tank-os-qemu.yaml
+++ b/examples/lima/tank-os-qemu.yaml
@@ -10,8 +10,16 @@
 #
 # See tank-os-vz.yaml (Apple Virtualization.framework) and
 # tank-os-krunkit.yaml (libkrun) for macOS-only alternatives -- all three
-# were confirmed working identically on Lima 2.2.0 / macOS M3 (2026-07-28).
+# were confirmed working identically on Lima 2.2.0 / macOS M3 (2026-07-28,
+# aarch64 only -- x86_64 hosts are untested but should work the same way,
+# see below).
 # See docs/quickstart-prebuilt.md for the full comparison and caveats.
+#
+# No `arch:` field on purpose -- Lima defaults it to the host's own
+# architecture, matching whatever qcow2 `podman create`/`cp` extracted
+# (quay.io/redhat-et/tank-os-containerdisk is a real multi-arch manifest
+# covering both arm64 and amd64, so this same config and disk-extraction
+# command work unmodified on an x86_64 host too, not just Apple Silicon).
 #
 # tank-os isn't a Lima-aware guest (no lima-guestagent), so this disables
 # mounts and containerd/dockerd provisioning that Lima normally sets up.
@@ -22,10 +30,8 @@
 # tank-os` and plain `ssh` both work. `limactl list` shows STATUS=Running
 # despite the non-zero exit code from `start`.
 vmType: "qemu"
-arch: "aarch64"
 images:
   - location: "~/.lima/_images/tank-os-disk.qcow2"
-    arch: "aarch64"
 cpus: 2
 memory: "4GiB"
 disk: "20GiB"

--- a/examples/lima/tank-os-qemu.yaml
+++ b/examples/lima/tank-os-qemu.yaml
@@ -1,0 +1,37 @@
+# Lima config for booting a tank-os disk pulled from
+# quay.io/redhat-et/tank-os-containerdisk, using Lima's QEMU driver
+# (works on both macOS and Linux hosts). Extract the qcow2 first:
+#
+#   podman create --name tank-os-extract quay.io/redhat-et/tank-os-containerdisk:latest
+#   podman cp tank-os-extract:/disk/disk.qcow2 ~/.lima/_images/tank-os-disk.qcow2
+#   podman rm tank-os-extract
+#
+# Then: limactl start --name tank-os ./tank-os-qemu.yaml
+#
+# See tank-os-vz.yaml (Apple Virtualization.framework) and
+# tank-os-krunkit.yaml (libkrun) for macOS-only alternatives -- all three
+# were confirmed working identically on Lima 2.2.0 / macOS M3 (2026-07-28).
+# See docs/quickstart-prebuilt.md for the full comparison and caveats.
+#
+# tank-os isn't a Lima-aware guest (no lima-guestagent), so this disables
+# mounts and containerd/dockerd provisioning that Lima normally sets up.
+#
+# `limactl start` itself exits non-zero and reports "DEGRADED" because the
+# guest agent never comes up -- that's expected and harmless here, not a
+# real failure. The VM is fully running at that point; `limactl shell
+# tank-os` and plain `ssh` both work. `limactl list` shows STATUS=Running
+# despite the non-zero exit code from `start`.
+vmType: "qemu"
+arch: "aarch64"
+images:
+  - location: "~/.lima/_images/tank-os-disk.qcow2"
+    arch: "aarch64"
+cpus: 2
+memory: "4GiB"
+disk: "20GiB"
+mounts: []
+containerd:
+  system: false
+  user: false
+ssh:
+  loadDotSSHPubKeys: true

--- a/examples/lima/tank-os-vz.yaml
+++ b/examples/lima/tank-os-vz.yaml
@@ -1,0 +1,24 @@
+# Lima config for booting tank-os using Apple's native Virtualization.framework
+# (vz) instead of QEMU -- macOS only, no HVF/QEMU firmware setup needed.
+# See tank-os-qemu.yaml for the image-extraction step and shared notes;
+# this file differs only in `vmType`.
+#
+# Confirmed working on Lima 2.2.0 / macOS M3 (2026-07-28): identical guest
+# behavior to the qemu variant (cloud-init, hostname, OpenClaw/OpenShell
+# bring-up), networked over vsock instead of QEMU's usermode NAT. Same
+# expected "DEGRADED" exit from `limactl start` -- see tank-os-qemu.yaml's
+# comment and docs/quickstart-prebuilt.md.
+vmType: "vz"
+arch: "aarch64"
+images:
+  - location: "~/.lima/_images/tank-os-disk.qcow2"
+    arch: "aarch64"
+cpus: 2
+memory: "4GiB"
+disk: "20GiB"
+mounts: []
+containerd:
+  system: false
+  user: false
+ssh:
+  loadDotSSHPubKeys: true

--- a/examples/lima/tank-os-vz.yaml
+++ b/examples/lima/tank-os-vz.yaml
@@ -1,7 +1,11 @@
 # Lima config for booting tank-os using Apple's native Virtualization.framework
 # (vz) instead of QEMU -- macOS only, no HVF/QEMU firmware setup needed.
 # See tank-os-qemu.yaml for the image-extraction step and shared notes;
-# this file differs only in `vmType`.
+# this file differs in `vmType` and in pinning `arch: "aarch64"` explicitly
+# (tank-os-qemu.yaml leaves `arch` unset since it's the one driver here
+# that's genuinely portable across host architectures -- vz is
+# Apple-Silicon-only regardless, so pinning it here is just documentation,
+# not a behavior difference).
 #
 # Confirmed working on Lima 2.2.0 / macOS M3 (2026-07-28): identical guest
 # behavior to the qemu variant (cloud-init, hostname, OpenClaw/OpenShell


### PR DESCRIPTION
Replaces #30, which GitHub auto-closed when its base branch
(`feature/openclaw-2026.7.1-openshell`) was deleted after PR #29's squash
merge. Same content, rebased onto `main`.

## Summary
- Package tank-os as a KubeVirt `containerDisk` (`deploy/containerdisk/`) and add an ArgoCD `ApplicationSet` (`deploy/applicationset.yaml`) that provisions one VM per user from a single-line list entry, via a Kustomize base (`deploy/base/`)
- Publish `tank-os`, `tank-claw-openshell`, and `tank-os-containerdisk` to `quay.io/redhat-et` (public read)
- Add `docs/quickstart-prebuilt.md`: run tank-os straight from the published images, no build tooling required — QEMU on macOS/Fedora, `bootc switch` on existing bootc hosts, and Lima (all three drivers: qemu, vz, krunkit)

## Test plan
- [x] Built and pushed all three images to `quay.io/redhat-et`, confirmed anonymous pull
- [x] `kustomize build deploy/base` renders valid YAML; `oc apply --dry-run=client` on the ApplicationSet
- [x] Manually verified the ApplicationSet's JSON6902 patch renders per-user name/labels/hostname correctly
- [x] Extracted `disk.qcow2` from the published containerdisk and booted it live under Lima 2.2.0 (qemu, vz, and krunkit drivers) on macOS/M3 — confirmed identical cloud-init, hostname, and OpenClaw/OpenShell bring-up across all three
- [ ] Full live-cluster verification against a real OpenShift Virtualization (CNV) cluster — checklist in `docs/openshift-virtualization.md`'s "First real cluster test" section, blocked on cluster access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OpenShift Virtualization support for provisioning per-user Tank OS virtual machines with automated namespaces, SSH access, and cloud-init configuration.
  - Added containerDisk image build and publishing commands, including architecture-specific publishing.
  - Added Lima configurations for QEMU, Virtualization.framework, and krunkit on macOS.
- **Documentation**
  - Added a prebuilt-image quickstart for macOS, Fedora, and Lima.
  - Added OpenShift Virtualization deployment, validation, and troubleshooting guidance.
  - Updated the setup checklist to include the prebuilt-image workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->