### PR TITLE
docs: rootful Podman requirement for build-qcow2 on bare Linux

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -132,20 +132,22 @@ On macOS with Podman Desktop, use the rootful Podman machine connection because
 bootc-image-builder needs privileged access to the container storage.
 
 **On a bare Linux host (RHEL, Fedora Workstation/Server, etc. — no Podman
-Desktop/machine layer)**: `build-qcow2`'s `--local` flag and its
-`-v /var/lib/containers/storage:/var/lib/containers/storage` bind-mount both
-require *rootful* Podman, and `--privileged` alone doesn't make a rootless
-invocation rootful — bootc-image-builder checks that the outer `podman`
-command itself is rootful, not just that the container it launches runs
-privileged. If you built the image as your own user (the Makefile's default,
-rootless Podman), `sudo make build-qcow2` alone will still fail to find it:
-rootless and rootful Podman keep entirely separate image storage
-(`sudo podman images` and `podman images` show different lists on the same
-host). Build and run both steps as root instead:
+Desktop/machine layer)**: `build-qcow2` and `build-iso` (they share the
+same `--local` flag and the same
+`-v /var/lib/containers/storage:/var/lib/containers/storage` bind-mount)
+both require *rootful* Podman, and `--privileged` alone doesn't make a
+rootless invocation rootful —
+bootc-image-builder checks that the outer `podman` command itself is
+rootful, not just that the container it launches runs privileged. If you
+built the image as your own user (the Makefile's default, rootless
+Podman), `sudo make build-qcow2`/`sudo make build-iso` alone will still
+fail to find it: rootless and rootful Podman keep entirely separate image
+storage (`sudo podman images` and `podman images` show different lists on
+the same host). Build and run all steps as root instead:
 
 ```bash
 sudo make build
-sudo make build-qcow2
+sudo make build-qcow2   # or: sudo make build-iso
 ```
 
 ## Makefile Targets
@@ -259,10 +261,19 @@ using `-nographic`.
 The `_4M` variant is preferred for modern systems; fall back to standard paths if unavailable.
 
 **RHEL note**: RHEL's `/usr/share/OVMF/` only ships `OVMF_CODE.secboot.fd`
-(no plain `OVMF_CODE.fd`), so the auto-detection above won't find it. The
-plain firmware lives at `/usr/share/edk2/ovmf/` instead — pass it
-explicitly: `OVMF_CODE=/usr/share/edk2/ovmf/OVMF_CODE.fd
-OVMF_VARS=/usr/share/edk2/ovmf/OVMF_VARS.fd`.
+(no plain `OVMF_CODE.fd`) — the plain firmware lives at
+`/usr/share/edk2/ovmf/` instead. `examples/boot-tank-os-qemu.sh` already
+searches that path automatically, so this only matters for the **manual**
+invocation above, which hardcodes a literal `/usr/share/OVMF/...` path and
+has no auto-detection at all. Override it explicitly:
+
+```bash
+export OVMF_CODE=/usr/share/edk2/ovmf/OVMF_CODE.fd
+export OVMF_VARS=/usr/share/edk2/ovmf/OVMF_VARS.fd
+```
+
+and substitute `$OVMF_CODE`/`$OVMF_VARS` for the hardcoded paths in the
+`-drive if=pflash,...` lines above.
 
 ## Launch on macOS (Apple Silicon, QEMU + HVF)
 
@@ -363,7 +374,7 @@ everything it wrote to the bind-mounted `out-tank-os/` directory. Reclaim it
 before resizing the disk or doing anything else as your own user:
 
 ```bash
-sudo chown -R "$(whoami):$(whoami)" out-tank-os
+sudo chown -R "$(id -un):$(id -gn)" out-tank-os
 ```
 
 **QEMU fails with `Could not set up host forwarding rule 'tcp::2222-:22'`**:
@@ -375,9 +386,12 @@ often a QEMU process from an earlier attempt that didn't exit cleanly.
 Find and stop it:
 
 ```bash
-sudo ss -ltnp | grep 2222      # or: sudo lsof -i:2222
-kill <pid-from-above>
+sudo lsof -ti:2222 | xargs -r kill
 ```
+
+(`ss -ltnp | grep 2222` also shows it, but the PID is buried inside
+`users:((...,pid=NNNN,...))` and isn't as easy to pull out and pipe to
+`kill` directly.)
 
 Then re-run the launch script or manual `qemu-system-*` invocation. If you
 need multiple VMs running at once instead, give each one a distinct

--- a/docs/build.md
+++ b/docs/build.md
@@ -131,6 +131,23 @@ out-tank-os/qcow2/disk.qcow2
 On macOS with Podman Desktop, use the rootful Podman machine connection because
 bootc-image-builder needs privileged access to the container storage.
 
+**On a bare Linux host (RHEL, Fedora Workstation/Server, etc. — no Podman
+Desktop/machine layer)**: `build-qcow2`'s `--local` flag and its
+`-v /var/lib/containers/storage:/var/lib/containers/storage` bind-mount both
+require *rootful* Podman, and `--privileged` alone doesn't make a rootless
+invocation rootful — bootc-image-builder checks that the outer `podman`
+command itself is rootful, not just that the container it launches runs
+privileged. If you built the image as your own user (the Makefile's default,
+rootless Podman), `sudo make build-qcow2` alone will still fail to find it:
+rootless and rootful Podman keep entirely separate image storage
+(`sudo podman images` and `podman images` show different lists on the same
+host). Build and run both steps as root instead:
+
+```bash
+sudo make build
+sudo make build-qcow2
+```
+
 ## Makefile Targets
 
 Common targets:

--- a/docs/build.md
+++ b/docs/build.md
@@ -354,6 +354,36 @@ substitution works on the Linux invocation above too — it isn't
 aarch64/macOS-specific, just documented here since it's what came up while
 testing this section.)
 
+## Troubleshooting
+
+**`out-tank-os` owned by root after `sudo make build-qcow2`**: on a bare
+Linux host you ran `sudo make build`/`sudo make build-qcow2` as documented
+above, so `bootc-image-builder` (running as root inside the container) owns
+everything it wrote to the bind-mounted `out-tank-os/` directory. Reclaim it
+before resizing the disk or doing anything else as your own user:
+
+```bash
+sudo chown -R "$(whoami):$(whoami)" out-tank-os
+```
+
+**QEMU fails with `Could not set up host forwarding rule 'tcp::2222-:22'`**:
+this is QEMU's usermode (`-netdev user`) networking failing to bind the
+forwarded port on the host — it doesn't need root (2222 is well above the
+privileged-port range), so adding `sudo` to the QEMU launch isn't the fix.
+It almost always means something is already listening on that port, most
+often a QEMU process from an earlier attempt that didn't exit cleanly.
+Find and stop it:
+
+```bash
+sudo ss -ltnp | grep 2222      # or: sudo lsof -i:2222
+kill <pid-from-above>
+```
+
+Then re-run the launch script or manual `qemu-system-*` invocation. If you
+need multiple VMs running at once instead, give each one a distinct
+`SSH_PORT` (or the equivalent `hostfwd` value in a manual invocation)
+rather than hunting down conflicts every time.
+
 ## Upgrade A Running VM
 
 After pushing a new bootc image, switch the VM to the registry ref:

--- a/examples/boot-tank-os-qemu.sh
+++ b/examples/boot-tank-os-qemu.sh
@@ -44,10 +44,18 @@ echo "CPU Cores: $QEMU_SMP"
 echo "SSH Port: localhost:$SSH_PORT"
 echo ""
 
-# Check QEMU availability
+# Check QEMU availability. RHEL doesn't ship a separate qemu-system-x86_64
+# binary -- its qemu-kvm package only installs /usr/libexec/qemu-kvm -- so
+# fall back to that if the default name isn't found, instead of requiring
+# QEMU_BIN=/usr/libexec/qemu-kvm to be set manually every time.
 if ! command -v "$QEMU_BIN" &> /dev/null; then
-    echo -e "${RED}ERROR: $QEMU_BIN not found. Install QEMU and retry.${NC}"
-    exit 1
+    if [[ "$QEMU_BIN" == "qemu-system-x86_64" ]] && command -v /usr/libexec/qemu-kvm &> /dev/null; then
+        echo -e "${YELLOW}-> qemu-system-x86_64 not found; using /usr/libexec/qemu-kvm (RHEL)${NC}"
+        QEMU_BIN="/usr/libexec/qemu-kvm"
+    else
+        echo -e "${RED}ERROR: $QEMU_BIN not found. Install QEMU and retry.${NC}"
+        exit 1
+    fi
 fi
 
 # Detect OVMF firmware files

--- a/examples/boot-tank-os-qemu.sh
+++ b/examples/boot-tank-os-qemu.sh
@@ -49,7 +49,7 @@ echo ""
 # fall back to that if the default name isn't found, instead of requiring
 # QEMU_BIN=/usr/libexec/qemu-kvm to be set manually every time.
 if ! command -v "$QEMU_BIN" &> /dev/null; then
-    if [[ "$QEMU_BIN" == "qemu-system-x86_64" ]] && command -v /usr/libexec/qemu-kvm &> /dev/null; then
+    if [[ "$(basename "$QEMU_BIN")" == "qemu-system-x86_64" ]] && [[ -x /usr/libexec/qemu-kvm ]]; then
         echo -e "${YELLOW}-> qemu-system-x86_64 not found; using /usr/libexec/qemu-kvm (RHEL)${NC}"
         QEMU_BIN="/usr/libexec/qemu-kvm"
     else

--- a/examples/boot-tank-os-qemu.sh
+++ b/examples/boot-tank-os-qemu.sh
@@ -55,8 +55,12 @@ detect_ovmf() {
     local code_fd=""
     local vars_fd=""
 
-    # Prefer 4M variants (most common on modern systems)
-    for path in /usr/share/OVMF /usr/share/ovmf /usr/share/edk2-ovmf; do
+    # Prefer 4M variants (most common on modern systems). /usr/share/edk2/ovmf
+    # is where RHEL puts the plain (non-secboot) firmware -- RHEL's
+    # /usr/share/OVMF only ships OVMF_CODE.secboot.fd, which this script
+    # doesn't look for, so without this path RHEL hosts fall through to the
+    # "OVMF firmware not found" error despite OVMF being installed.
+    for path in /usr/share/OVMF /usr/share/ovmf /usr/share/edk2-ovmf /usr/share/edk2/ovmf; do
         if [[ -f "$path/OVMF_CODE_4M.fd" ]]; then
             code_fd="$path/OVMF_CODE_4M.fd"
             [[ -f "$path/OVMF_VARS_4M.fd" ]] && vars_fd="$path/OVMF_VARS_4M.fd"


### PR DESCRIPTION
## Summary
- Document why \`make build-qcow2\` fails with "this command must be run in
  rootful (not rootless) podman" on a bare Linux host (RHEL, Fedora
  Workstation/Server) that has no Podman Desktop/machine layer
- Clarify that both \`make build\` and \`make build-qcow2\` need to run as
  root (\`sudo\`) on such hosts, not just the failing command — rootless and
  rootful Podman keep separate image storage, so building the image
  rootless leaves it invisible to a rootful \`build-qcow2\` run

## Test plan
- [ ] Not yet verified on a live RHEL host in this session — based on
  Podman's well-established rootless/rootful storage separation and
  bootc-image-builder's own error message. Flagging this explicitly:
  if you (or whoever reported the original error) can confirm
  \`sudo make build && sudo make build-qcow2\` actually resolves it,
  that closes the loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for building disk images on bare Linux hosts using rootful Podman.
  * Expanded RHEL QEMU firmware setup instructions, including OVMF configuration.
  * Added troubleshooting steps for file ownership and SSH port-forwarding conflicts.
* **Bug Fixes**
  * Improved QEMU detection on RHEL by supporting the `/usr/libexec/qemu-kvm` path.
  * Added support for detecting OVMF firmware in additional RHEL locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->