### PR TITLE
docs: fix missing disk resize step in vfkit quickstart

### DIFF
--- a/docs/quickstart-prebuilt.md
+++ b/docs/quickstart-prebuilt.md
@@ -112,8 +112,13 @@ Fedora container:
 
 ```bash
 podman run --rm -v "$PWD":/data registry.fedoraproject.org/fedora-minimal:latest \
-  bash -c "microdnf install -y qemu-img -q && qemu-img convert -p -O raw /data/tank-os-disk.qcow2 /data/tank-os-disk.raw"
+  bash -c "microdnf install -y qemu-img -q && qemu-img resize /data/tank-os-disk.qcow2 20G && qemu-img convert -p -O raw /data/tank-os-disk.qcow2 /data/tank-os-disk.raw"
 ```
+
+The published containerdisk's qcow2 isn't pre-sized to 20G, so the resize
+has to happen before conversion here — same requirement as the QEMU section
+below, just folded into this disposable container instead of a separate
+host-installed `qemu-img` step.
 
 The result is a sparse file — `ls -la` reports the full 20G, but `du -h`
 shows only the actual data (macOS's APFS handles the sparseness natively,


### PR DESCRIPTION
## Summary
- The vfkit quickstart section converted the extracted containerdisk qcow2 to raw without resizing it to 20G first, unlike the QEMU section immediately below it which does resize the same extracted disk.
- Folds `qemu-img resize` into the same disposable Fedora container already used for the `qemu-img convert` step, so no extra host dependency is needed.

## Test plan
- [x] Verified end-to-end on macOS/aarch64: extract, resize+convert, boot with vfkit, confirmed disk shows full 20G.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the macOS quickstart to clarify the required disk resizing step before conversion.
  * Added guidance for using a disposable container workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->