### PR TITLE
docs: document dashboard secure-context error and port-forward block

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,6 +28,58 @@ fragment, for example `http://127.0.0.1:18789/#token=...`. If the token is
 SecretRef-managed, OpenClaw intentionally prints a non-tokenized URL and asks you
 to use the external token source instead.
 
+### Browser secure-context requirement
+
+Opening the dashboard at the VM's own routable IP (for example
+`http://192.168.64.2:18789/`, as vfkit hands out) fails with:
+
+```text
+control ui requires device identity (use HTTPS or localhost secure context)
+```
+
+This is enforced by the browser, not by OpenClaw's config — device identity
+uses Web Crypto APIs that browsers only expose in a "secure context"
+(`https:`, or `http://localhost`/`http://127.0.0.1`). Plain `http://` against
+any other host, including the VM's LAN/NAT IP, is refused before OpenClaw
+even sees a connection attempt. There is no config setting to disable this;
+the retired `gateway.controlUi.dangerouslyDisableDeviceAuth` break-glass only
+covers migrating browsers that used it in an older release, not new setups.
+
+The fix is an SSH local port-forward so the browser sees `localhost`:
+
+```bash
+ssh -L 18789:127.0.0.1:18789 openclaw@<vm-ip>
+```
+
+Then open `http://127.0.0.1:18789/` — `openclaw dashboard --no-open`'s
+printed token works as-is here since both sides already say `18789`.
+
+**If that SSH command is killed outright** (`zsh: killed ssh -L
+18789:127.0.0.1:18789 ...`, no further error) — some corporate security
+tooling terminates local port-forwards to this specific port. Work around it
+by moving the Gateway's own listening port instead of the tunnel's local
+side, so `18789` never appears as the tunnel's remote target:
+
+1. On the VM, edit the Quadlet's `--port` argument in
+   `/etc/containers/systemd/users/1000/openclaw.container` (`Exec=node
+   dist/index.js gateway --allow-unconfigured --bind lan --port 18789` →
+   `--port 28789`, or any other free port).
+2. `systemctl --user daemon-reload && systemctl --user restart openclaw.service`
+3. Tunnel with the ports swapped from the blocked command — local `18789`,
+   remote `28789`:
+   ```bash
+   ssh -L 18789:127.0.0.1:28789 openclaw@<vm-ip>
+   ```
+4. Open `http://127.0.0.1:18789/` as before. Keeping the *local* side at
+   `18789` means `controlUi.allowedOrigins` (which lists
+   `http://127.0.0.1:18789`/`http://localhost:18789` by default) doesn't
+   need editing — only the origin your browser presents matters, not the
+   VM-side port behind the tunnel.
+
+This resets on VM recreation (`bootstrap-openclaw` only sets the default
+port/origins on first boot) — redo it if you rebuild the VM and hit the same
+block.
+
 The wrapper targets the `openclaw` container by default. To target another
 container, either use `--container`:
 

--- a/docs/quickstart-prebuilt.md
+++ b/docs/quickstart-prebuilt.md
@@ -182,6 +182,11 @@ That address is also recorded in `/var/db/dhcpd_leases` on the host if you
 need to look it up again later, but it's simplest to just read it off
 `console.log`.
 
+Opening the OpenClaw dashboard directly at that IP (`http://192.168.64.2:18789/`)
+will fail with a browser secure-context error — see `docs/cli.md`'s
+"Browser secure-context requirement" for why, the SSH-tunnel fix, and a
+workaround if your network blocks SSH local port-forwarding to that port.
+
 **Verified on macOS/aarch64 (M3), 2026-07-30:** clean boot with no PCI
 option-ROM/TPM log noise at all (Apple's EFI implementation doesn't probe
 PCI option ROMs the way OVMF does — see the QEMU section's note on that),


### PR DESCRIPTION
## Summary
- Documents the browser "control ui requires device identity" error hit when opening the OpenClaw dashboard directly at a VM's LAN/NAT IP instead of via localhost -- it's a browser secure-context restriction, not something OpenClaw's config can disable in current releases.
- Documents the standard SSH local-port-forward fix.
- Documents a workaround for networks that terminate SSH local port-forwards to port 18789 specifically: move the Gateway's own listening port and tunnel with the local/remote sides swapped.
- Cross-links from the vfkit quickstart's SSH section.

## Test plan
- [x] Verified end-to-end on macOS/aarch64 against a Red Hat corporate network that kills `ssh -L 18789:127.0.0.1:18789 ...`; the port-swap workaround restored dashboard access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for securely accessing the dashboard when running through a VM.
  * Documented the browser error caused by direct HTTP access and provided an SSH port-forwarding solution.
  * Added a workaround for tools that terminate tunnels using the default remote port.
  * Updated the quickstart guide with secure-access requirements and troubleshooting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->