### PR TITLE
docs: document injecting Podman secrets from the host over SSH

### DIFF
--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -244,6 +244,35 @@ systemctl --user restart openclaw.service
 
 Create Podman secrets in the `openclaw` user's rootless store and inject them into the OpenClaw container.
 
+### Injecting Secrets From the Host
+
+The sections below assume an interactive session on the VM (`sudo -iu openclaw`
+or a direct `ssh openclaw@<host>` login). If you keep credentials on your
+development machine instead, you do not need an interactive shell at all —
+pipe the value straight to `podman secret create` over SSH:
+
+```bash
+printf '%s' "$ANTHROPIC_API_KEY" | ssh openclaw@<host> "podman secret create anthropic_api_key -"
+```
+
+Use `printf '%s'`, not `echo`, so the secret does not pick up a trailing
+newline. Substitute `<host>` (and any port, e.g. `-p "$PORT"` for the
+[local macOS VM](#local-macos-vm) forwarded-port case) with whatever you'd use
+to reach the instance elsewhere in this doc. This only works unattended
+because the cloud-init template enables lingering for `openclaw`
+(`loginctl enable-linger openclaw`); without it, rootless Podman may not have
+a runtime session ready for a non-interactive SSH command.
+
+Apply the secret and restart the service the same way:
+
+```bash
+ssh openclaw@<host> "tank-openclaw-secrets && systemctl --user restart openclaw.service"
+```
+
+Avoid typing the raw secret value directly into a command (it lands in shell
+history); export it from a password manager or prompt for it with `read -s`
+instead.
+
 ### Gateway Token Setup
 
 Execute the following commands to create the Openclaw Gateway Token:

--- a/docs/quickstart-prebuilt.md
+++ b/docs/quickstart-prebuilt.md
@@ -449,3 +449,24 @@ Verify from inside the guest:
 limactl shell tank-os -- sudo -u openclaw \
   env XDG_RUNTIME_DIR=/run/user/1000 openshell sandbox get tankos-openclaw
 ```
+
+## Give OpenClaw a model provider key
+
+The extracted image ships with no model provider configured — OpenClaw needs
+at least one API key before it can respond to anything. As with the SSH key
+above, you don't need an interactive shell on the VM for this: pipe the value
+straight to `podman secret create` over SSH, using whichever `openclaw@<host>`
+address the platform section above used to reach the VM (add `-p <port>` for
+the QEMU/`virt-install` paths that forward a local port instead of exposing a
+routable IP):
+
+```bash
+printf '%s' "$ANTHROPIC_API_KEY" | ssh openclaw@<host> "podman secret create anthropic_api_key -"
+ssh openclaw@<host> "tank-openclaw-secrets && systemctl --user restart openclaw.service"
+```
+
+See [model-providers.md](model-providers.md) for the full list of supported
+secret names, and
+[provisioning.md](provisioning.md#injecting-secrets-from-the-host) for the
+gateway-token equivalent and why this works without an interactive login
+session.


### PR DESCRIPTION
## Summary
- Document a host-side pattern for creating Podman secrets over SSH without an interactive shell on the VM, in both `docs/provisioning.md` and `docs/quickstart-prebuilt.md`.
- Notes why `printf '%s'` (not `echo`) matters and why this works unattended (cloud-init's `loginctl enable-linger openclaw`).

## Test plan
- [x] Docs-only change; verified against markdown style guide (headings, fenced code blocks, blank lines).
- [x] Cross-checked that this pattern wasn't already documented elsewhere in the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for securely provisioning Podman secrets remotely or interactively.
  * Documented piping credentials over SSH without storing them in shell history.
  * Added steps for activating secrets and restarting services remotely.
  * Expanded quickstart instructions for configuring model provider API keys and gateway tokens.
  * Included notes on newline-free input, forwarded SSH ports, cloud-init lingering, and safer secret entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->