### PR TITLE
fix: register OpenShell gateway with CLI before sandbox create

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CSB_IMAGE_TAG ?= quay.io/redhat-et/openclaw:csb-2026.07.21
 # installs on the host -- its own ARG default exists only for standalone
 # builds run without this Makefile, and must be bumped together with
 # this value.
-OPENSHELL_VERSION ?= 0.0.92
+OPENSHELL_VERSION ?= 0.0.99
 
 # KubeVirt containerDisk (wraps out-tank-os/qcow2/disk.qcow2, see
 # deploy/containerdisk/Containerfile) -- override if you're publishing to

--- a/bootc/Containerfile
+++ b/bootc/Containerfile
@@ -22,7 +22,7 @@ ARG CSB_IMAGE_TAG=quay.io/redhat-et/openclaw:csb-2026.07.21
 
 # OpenShell CLI + gateway RPMs, pinned to a tagged release rather than
 # `latest` for reproducible builds.
-ARG OPENSHELL_VERSION=0.0.92
+ARG OPENSHELL_VERSION=0.0.99
 
 RUN set -eux; \
     dnf -y install \

--- a/bootc/rootfs/usr/libexec/tank-os/bootstrap-csb-sandbox
+++ b/bootc/rootfs/usr/libexec/tank-os/bootstrap-csb-sandbox
@@ -44,11 +44,20 @@ secret_exists() {
 # Without it every `openshell` command below fails immediately with "No
 # active gateway", silently (the sandbox-create call two steps down redirects
 # to /dev/null), and this script's poll loop spins for the full 600s waiting
-# on a Ready state nothing can ever produce. `openshell status` succeeding
-# is our signal that a previous run (or first-boot registration on an
-# earlier start) already did this.
-if ! openshell status >/dev/null 2>&1; then
-  openshell gateway add --local https://127.0.0.1:17670
+# on a Ready state nothing can ever produce.
+#
+# `openshell status` always exits 0 -- even when unconfigured, it just
+# prints "No gateway configured." -- so it can't be used as a guard here.
+# `openshell gateway add` itself isn't idempotent either: run a second time
+# it exits 1 with "Gateway 'openshell' already exists." That's the one
+# expected failure on every boot after the first, so treat it (and only it)
+# as success; any other failure means registration is genuinely broken and
+# should stop the script rather than let it silently spin for 600s again.
+if ! add_output="$(openshell gateway add --local https://127.0.0.1:17670 2>&1)"; then
+  if ! grep -q "already exists" <<<"$add_output"; then
+    echo "bootstrap-csb-sandbox: gateway registration failed: $add_output" >&2
+    exit 1
+  fi
 fi
 
 # --- 2. Wipe any staged-secret leftovers from a prior run -------------------

--- a/bootc/rootfs/usr/libexec/tank-os/bootstrap-csb-sandbox
+++ b/bootc/rootfs/usr/libexec/tank-os/bootstrap-csb-sandbox
@@ -7,20 +7,23 @@ set -euo pipefail
 # systemd --user unit, not a Podman Quadlet -- CSB's own image is run via
 # `openshell sandbox create`, not `podman run` directly).
 #
-# Four jobs, all idempotent except the sandbox itself (recreated fresh on
+# Five jobs, all idempotent except the sandbox itself (recreated fresh on
 # every start -- Open Question 7's "no dependency on StartupResume"):
-#   1. Auto-provision the gateway token as a Podman secret on first boot,
+#   1. Register the local gateway with the CLI, if it isn't already --
+#      required once per boot before any other `openshell` command below can
+#      succeed (see step 1's comment for why this is needed at all).
+#   2. Auto-provision the gateway token as a Podman secret on first boot,
 #      mirroring bootstrap-openclaw's old self-service UX.
-#   2. Register/update OpenShell providers for whichever of CSB's
+#   3. Register/update OpenShell providers for whichever of CSB's
 #      provider-routed credentials (openai, github) tank-os has a secret
 #      for (Finding I).
-#   3. Stage whichever of CSB's read_secret()-routed keys (Finding G/K)
+#   4. Stage whichever of CSB's read_secret()-routed keys (Finding G/K)
 #      tank-os has a secret for, via --upload + a shell-wrapper trailing
 #      command -- never via --env/--credential with a literal value.
-#   4. Delete any sandbox left over from a prior start, then run
+#   5. Delete any sandbox left over from a prior start, then run
 #      `openshell sandbox create` in the background and poll until the
 #      sandbox reports Ready (Finding L: the CLI's foreground attachment is
-#      cosmetic, not the supervised workload -- see step 5 below).
+#      cosmetic, not the supervised workload -- see step 7 below).
 
 csb_image="${CSB_IMAGE_TAG:-__CSB_IMAGE_TAG_DEFAULT__}"
 sandbox_name="tank-csb"
@@ -30,21 +33,39 @@ secret_exists() {
   podman secret inspect "$1" >/dev/null 2>&1
 }
 
-# --- 0. Wipe any staged-secret leftovers from a prior run -------------------
+# --- 1. Register the local gateway with the CLI ----------------------------
+#
+# openshell-gateway.service generates a self-signed mTLS client bundle at
+# ~/.config/openshell/gateways/openshell/mtls/ on its own first start (its
+# ExecStartPre runs `openshell-gateway generate-certs`), but nothing
+# registers that bundle with the CLI -- per OpenShell's own
+# /usr/share/doc/openshell-gateway/QUICKSTART.md ("Register the gateway with
+# the CLI"), that is a separate, explicit `openshell gateway add` step.
+# Without it every `openshell` command below fails immediately with "No
+# active gateway", silently (the sandbox-create call two steps down redirects
+# to /dev/null), and this script's poll loop spins for the full 600s waiting
+# on a Ready state nothing can ever produce. `openshell status` succeeding
+# is our signal that a previous run (or first-boot registration on an
+# earlier start) already did this.
+if ! openshell status >/dev/null 2>&1; then
+  openshell gateway add --local https://127.0.0.1:17670
+fi
+
+# --- 2. Wipe any staged-secret leftovers from a prior run -------------------
 #
 # upload_dir is a FIXED, well-known path (tmpfs-backed, never touches
 # persistent disk) rather than a mktemp -d location. This is deliberate: step
-# 5 below backgrounds `openshell sandbox create` and this script exits (after
+# 7 below backgrounds `openshell sandbox create` and this script exits (after
 # polling for Ready) while that backgrounded process is still running --
 # there is no point at which this script could safely `rm` the upload
 # directory itself, because `openshell` (the thing that actually reads the
 # files via --upload) may still be reading them asynchronously after this
-# script has exited (see step 5's comment for why it can't `exec` into
+# script has exited (see step 7's comment for why it can't `exec` into
 # `create` and let that be the cleanup boundary instead). So cleanup cannot
 # happen at the *end* of a successful run; instead, every run wipes and
 # recreates this fixed directory at the *start*, before staging any new
 # secrets into it. This mirrors the same "delete-then-create fresh every
-# start" philosophy step 4 already applies to the sandbox itself. Exposure is
+# start" philosophy step 6 already applies to the sandbox itself. Exposure is
 # bounded to "the currently-running instance's files, for as long as that
 # instance is alive" rather than "accumulating leftover directories
 # forever."
@@ -61,13 +82,13 @@ read_secret_value() {
   printf '%s' "$value"
 }
 
-# --- 1. Auto-provision the gateway token -----------------------------------
+# --- 3. Auto-provision the gateway token -----------------------------------
 
 if ! secret_exists openclaw_gateway_token; then
   openssl rand -hex 32 | podman secret create openclaw_gateway_token -
 fi
 
-# --- 2. Provider registration (Finding I, Open Question 7) -----------------
+# --- 4. Provider registration (Finding I, Open Question 7) -----------------
 
 register_provider() {
   local name="$1" type="$2" env_var="$3" secret_name="$4" secval
@@ -89,7 +110,7 @@ provider_args=()
 openshell provider get openai-claw >/dev/null 2>&1 && provider_args+=(--provider openai-claw)
 openshell provider get github-claw >/dev/null 2>&1 && provider_args+=(--provider github-claw)
 
-# --- 3. Stage non-provider-routed secrets for --upload (Finding K) ---------
+# --- 5. Stage non-provider-routed secrets for --upload (Finding K) ---------
 
 upload_args=()
 wrapper_lines=()
@@ -122,7 +143,7 @@ stage_secret cohere_api_key  COHERE_API_KEY  optional
 
 wrapper="$(printf '%s ' "${wrapper_lines[@]}")exec /app/entrypoint.sh"
 
-# --- 4. Recreate the sandbox fresh every start, then exec into it ----------
+# --- 6. Recreate the sandbox fresh every start, then exec into it ----------
 
 openshell sandbox delete "$sandbox_name" >/dev/null 2>&1 || true
 
@@ -140,10 +161,10 @@ done
 # upload_dir is intentionally NOT removed here. The `create` below runs in
 # the background and this script exits while it's still starting up, so no
 # bash code here can run "after openshell has read the files" -- the
-# wipe-and-recreate at the top of the script (step 0) is what cleans up, on
+# wipe-and-recreate at the top of the script (step 2) is what cleans up, on
 # the *next* run, before that run stages its own fresh secrets.
 
-# --- 5. Create in the background, then poll for Ready (Finding L) ----------
+# --- 7. Create in the background, then poll for Ready (Finding L) ----------
 #
 # Finding L: killing the `openshell sandbox create` CLI process does not
 # tear down the sandbox -- the CLI's foreground attachment is cosmetic (a

--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -56,20 +56,26 @@ one.
 Unlike a service that resumes previous state, `openclaw.service` recreates
 `tank-csb` from scratch on every start (no dependency on OpenShell's
 `StartupResume` — see `docs/dev/csb-bootc-deployment-design.md` Finding
-L). Its `ExecStart`, `bootstrap-csb-sandbox`, does four things, all
+L). Its `ExecStart`, `bootstrap-csb-sandbox`, does five things, all
 idempotent except the sandbox itself:
 
-1. Auto-provisions the `openclaw_gateway_token` Podman secret on first
+1. Registers the local gateway with the CLI (`openshell gateway add --local
+   https://127.0.0.1:17670`), if `openshell status` shows it isn't already.
+   `openshell-gateway.service` generates its own mTLS client bundle on first
+   start, but nothing else registers it with the CLI — without this step,
+   every subsequent `openshell` command in the script fails immediately
+   with "No active gateway."
+2. Auto-provisions the `openclaw_gateway_token` Podman secret on first
    boot, if it doesn't already exist.
-2. Registers/updates OpenShell providers (`openai-claw`, `github-claw`)
+3. Registers/updates OpenShell providers (`openai-claw`, `github-claw`)
    for whichever of CSB's provider-routed credentials (`openai_api_key`,
    `gh_token`) tank-os has a Podman secret for.
-3. Stages whichever of CSB's `read_secret()`-routed keys (gateway token,
+4. Stages whichever of CSB's `read_secret()`-routed keys (gateway token,
    and any of the anthropic/gemini-or-google/xai/mistral/cohere keys)
    tank-os has a secret for, via `--upload` plus a shell-wrapper trailing
    command — never via a literal `--env`/`--credential` value, which would
    put the real secret in the process's argv.
-4. Deletes any sandbox left over from a prior start, then runs
+5. Deletes any sandbox left over from a prior start, then runs
    `openshell sandbox create` in the background and polls `openshell
    sandbox get tank-csb` until it reports `Ready` (or times out at 600s).
 

--- a/docs/openshell.md
+++ b/docs/openshell.md
@@ -60,11 +60,13 @@ L). Its `ExecStart`, `bootstrap-csb-sandbox`, does five things, all
 idempotent except the sandbox itself:
 
 1. Registers the local gateway with the CLI (`openshell gateway add --local
-   https://127.0.0.1:17670`), if `openshell status` shows it isn't already.
-   `openshell-gateway.service` generates its own mTLS client bundle on first
-   start, but nothing else registers it with the CLI — without this step,
-   every subsequent `openshell` command in the script fails immediately
-   with "No active gateway."
+   https://127.0.0.1:17670`), tolerating the "already exists" failure `add`
+   returns on every boot after the first (`openshell status` always exits
+   0 even when unconfigured, so it can't be used as a guard here).
+   `openshell-gateway.service` generates its own mTLS client bundle on
+   first start, but nothing else registers it with the CLI — without this
+   step, every subsequent `openshell` command in the script fails
+   immediately with "No active gateway."
 2. Auto-provisions the `openclaw_gateway_token` Podman secret on first
    boot, if it doesn't already exist.
 3. Registers/updates OpenShell providers (`openai-claw`, `github-claw`)


### PR DESCRIPTION
## Summary

- `openclaw.service` was stuck in `activating` forever on every fresh boot: `openshell-gateway.service` generates its own mTLS client bundle on first start, but nothing ever ran the corresponding `openshell gateway add` step from OpenShell's own QUICKSTART.md. Without it, every `openshell sandbox` call in `bootstrap-csb-sandbox` failed immediately and silently (output redirected to `/dev/null`), so the script's poll loop spun for the full 600s before failing.
- Add that registration as an idempotent first step in `bootstrap-csb-sandbox`. `openshell status` can't guard it (always exits 0, even when unconfigured); `openshell gateway add` isn't idempotent either (exits 1 with "already exists" on repeat boots), so the guard treats that specific failure as expected and surfaces anything else.
- Bump `OPENSHELL_VERSION` 0.0.92 → 0.0.99 (published 2026-08-05) while in here — reviewed the changelog across that range, no changes affect the CLI behavior tank-os depends on.

## Test plan

- [x] `shellcheck` and `bash -n` clean on `bootstrap-csb-sandbox`
- [x] `markdownlint-cli2` clean on `docs/openshell.md`
- [x] `make build ARCH=arm64` succeeds, RPM checksums verified against the real v0.0.99 release
- [x] Unit-tested the registration guard against fake `openshell` outputs for all three paths: fresh registration, already-registered no-op, genuine unrelated failure (still aborts loudly)
- [x] End-to-end on a fresh macOS/QEMU VM: `openclaw.service` reaches `active (exited)`, `tank-csb` sandbox container `Up ... (healthy)`, dashboard forward bound on 18789

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the bundled OpenShell release to version 0.0.99.
  * Startup now registers the local gateway before configuring and launching the sandbox.
  * Registration safely handles gateways that are already configured while reporting unexpected failures.

* **Documentation**
  * Updated the startup sequence documentation to reflect the gateway registration step and revised provisioning flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->