### PR TITLE
fix: mask bootc-fetch-apply-updates.timer to stop boot failure

### DIFF
--- a/bootc/Containerfile
+++ b/bootc/Containerfile
@@ -61,6 +61,12 @@ RUN set -eux; \
 
 COPY rootfs/ /
 
+# bootc-fetch-apply-updates.timer is enabled by default on the Fedora
+# bootc base and polls whatever registry origin is baked into the image.
+# tank-os only supports updates via manual `bootc switch`/`bootc upgrade`
+# (see docs/build.md), so the timer just fails on every boot -- most
+# visibly on images built locally with the default `localhost/tank-os`
+# tag, where there's no registry to poll at all.
 RUN set -eux; \
     chmod 0755 \
       /usr/local/bin/openclaw \
@@ -75,6 +81,7 @@ RUN set -eux; \
     sed -i "s|__CSB_IMAGE_TAG_DEFAULT__|${CSB_IMAGE_TAG}|" \
       /usr/libexec/tank-os/bootstrap-csb-sandbox; \
     systemctl enable sshd.service; \
+    systemctl mask bootc-fetch-apply-updates.timer; \
     mkdir -p /etc/systemd/user/default.target.wants; \
     ln -sf /usr/lib/systemd/user/openshell-gateway.service \
       /etc/systemd/user/default.target.wants/openshell-gateway.service; \


### PR DESCRIPTION
## Summary
- `bootc-fetch-apply-updates.timer` is enabled by default on the Fedora bootc base and polls whatever registry origin is baked into the image at build time.
- tank-os only supports updates via manual `bootc switch`/`bootc upgrade` (see docs/build.md) — there's no documented reliance on the automatic timer.
- Locally built images use the Makefile's default `localhost/tank-os` origin (no `IMAGE_REGISTRY`/`IMAGE_NAMESPACE` set), so the timer fires against `localhost` inside the guest VM, which isn't a reachable registry — surfacing as `Failed Units: 1` (`bootc-fetch-apply-updates.service`) on every login.
- Fix: mask the timer in `bootc/Containerfile` so it never starts. Manual `bootc upgrade --apply` is unaffected.

## Test plan
- [x] `make build` — image builds successfully with the mask applied
- [x] `podman run --rm localhost/tank-os:latest systemctl is-enabled bootc-fetch-apply-updates.timer` → `masked`
- [x] `make lint` (`bootc container lint`) — 10 checks passed, only pre-existing unrelated warnings
- [x] Built qcow2 (`sudo make build && sudo make build-qcow2`), booted a fresh VM — `Failed Units: 0`, `bootc-fetch-apply-updates` no longer appears in `journalctl`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that system updates are performed manually rather than automatically.

* **Bug Fixes**
  * Disabled the automatic update timer in the built image to prevent unintended scheduled updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->