### PR TITLE
feat: persist OpenClaw state across sandbox restarts

### DIFF
--- a/bootc/Containerfile
+++ b/bootc/Containerfile
@@ -20,6 +20,12 @@ ARG OPENCLAW_SUBID_COUNT=65536
 # daily; do not use csb-latest here.
 ARG CSB_IMAGE_TAG=quay.io/redhat-et/openclaw:csb-2026.07.21
 
+# Default model for a fresh OpenClaw config. The upstream openclaw-csb demo
+# runbook's own pinned value (openai/gpt-5.5) turned out to no longer be a
+# model OpenAI serves; re-pinning here should be a build-arg bump, not a
+# bootstrap-csb-sandbox edit.
+ARG OPENCLAW_DEFAULT_MODEL=openai/gpt-5.5-pro
+
 # OpenShell CLI + gateway RPMs, pinned to a tagged release rather than
 # `latest` for reproducible builds.
 ARG OPENSHELL_VERSION=0.0.99
@@ -79,6 +85,8 @@ RUN set -eux; \
     chmod 0440 /etc/sudoers.d/openclaw; \
     chown -R openclaw:openclaw /var/home/openclaw; \
     sed -i "s|__CSB_IMAGE_TAG_DEFAULT__|${CSB_IMAGE_TAG}|" \
+      /usr/libexec/tank-os/bootstrap-csb-sandbox; \
+    sed -i "s|__OPENCLAW_DEFAULT_MODEL_DEFAULT__|${OPENCLAW_DEFAULT_MODEL}|" \
       /usr/libexec/tank-os/bootstrap-csb-sandbox; \
     systemctl enable sshd.service; \
     systemctl mask bootc-fetch-apply-updates.timer; \

--- a/bootc/rootfs/usr/libexec/tank-os/bootstrap-csb-sandbox
+++ b/bootc/rootfs/usr/libexec/tank-os/bootstrap-csb-sandbox
@@ -24,13 +24,27 @@ set -euo pipefail
 #      `openshell sandbox create` in the background and poll until the
 #      sandbox reports Ready (Finding L: the CLI's foreground attachment is
 #      cosmetic, not the supervised workload -- see step 7 below).
+#
+# The sandbox's own overlay filesystem does NOT survive step 5's
+# delete/create cycle -- confirmed empirically, not just inferred: OpenClaw's
+# config/session state under ~/.openclaw reverted to image defaults after a
+# routine restart. Step 4b mounts a persistent Podman volume (the
+# openclaw-csb demo runbook's own pattern) and points OpenClaw's state/
+# workspace dirs at it so that state survives independently of the sandbox
+# instance's lifecycle.
 
 csb_image="${CSB_IMAGE_TAG:-__CSB_IMAGE_TAG_DEFAULT__}"
 sandbox_name="tank-csb"
 upload_dir="/dev/shm/tank-os-csb-upload"
+persist_volume="tank-openclaw-data"
+persist_mount_target="/sandbox/persist"
 
 secret_exists() {
   podman secret inspect "$1" >/dev/null 2>&1
+}
+
+volume_exists() {
+  podman volume inspect "$1" >/dev/null 2>&1
 }
 
 # --- 1. Register the local gateway with the CLI ----------------------------
@@ -116,8 +130,63 @@ register_provider openai-claw openai OPENAI_API_KEY openai_api_key
 register_provider github-claw github GH_TOKEN gh_token
 
 provider_args=()
-openshell provider get openai-claw >/dev/null 2>&1 && provider_args+=(--provider openai-claw)
+openai_provider_attached=false
+if openshell provider get openai-claw >/dev/null 2>&1; then
+  provider_args+=(--provider openai-claw)
+  openai_provider_attached=true
+fi
 openshell provider get github-claw >/dev/null 2>&1 && provider_args+=(--provider github-claw)
+
+# --- 4b. Persistent state volume (openclaw-csb demo-runbook pattern) -------
+#
+# --driver-config-json passes a raw podman mount spec through to the
+# sandbox's container, attaching a named Podman volume that outlives
+# `openshell sandbox delete` the same way any podman volume outlives
+# `podman rm` of a container that used it. Redirecting
+# OPENCLAW_STATE_DIR/OPENCLAW_WORKSPACE_DIR onto that mount moves
+# OpenClaw's config, session/auth store, and workspace off the ephemeral
+# sandbox overlay and onto durable storage.
+if ! volume_exists "$persist_volume"; then
+  podman volume create "$persist_volume" >/dev/null
+  # Fresh volumes are root-owned; the sandbox runs as the unprivileged
+  # `sandbox` user (policy's process.run_as_user), so it needs a writable
+  # mount from the start. One-time fix -- not repeated once the volume
+  # already exists, so this doesn't cost an extra container run on every
+  # restart.
+  podman run --rm --user 0 --entrypoint /bin/sh \
+    -v "${persist_volume}:/data" \
+    "$csb_image" \
+    -c 'chmod 0777 /data'
+fi
+
+driver_config_json="$(printf '{"podman":{"mounts":[{"type":"volume","source":"%s","target":"%s","read_only":false}]}}' \
+  "$persist_volume" "$persist_mount_target")"
+
+# Build-time ARG (bootc/Containerfile), not hardcoded here, because this is
+# the exact failure mode this value caused: the upstream openclaw-csb demo
+# runbook pins a model name OpenAI no longer serves. Re-pinning should be a
+# build-arg bump, not a script edit.
+default_model="${OPENCLAW_DEFAULT_MODEL:-__OPENCLAW_DEFAULT_MODEL_DEFAULT__}"
+
+sandbox_env_args=(
+  --env "OPENCLAW_STATE_DIR=${persist_mount_target}/.openclaw"
+  --env "OPENCLAW_WORKSPACE_DIR=${persist_mount_target}/workspace"
+  --env "OPENCLAW_DEFAULT_MODEL=${default_model}"
+)
+
+# OpenClaw's models.providers.<name>.models[] catalog has no entry for a
+# model unless something puts one there -- discovered the hard way when
+# `openclaw models set` alone produced "Unknown model" at runtime, because
+# it only updates agents.defaults.models, a separate schema location.
+# OPENCLAW_PROVIDERS seeds the catalog declaratively on every sandbox
+# creation, so this gap can't reappear after a volume reset or fresh
+# install the way a one-off `openclaw config patch` would.
+if [[ "$openai_provider_attached" == true ]]; then
+  openai_model_id="${default_model#openai/}"
+  openclaw_providers_json="$(printf '{"openai":{"api":"openai-responses","baseUrl":"https://api.openai.com/v1","models":[{"id":"%s","name":"%s"}]}}' \
+    "$openai_model_id" "$openai_model_id")"
+  sandbox_env_args+=(--env "OPENCLAW_PROVIDERS=${openclaw_providers_json}")
+fi
 
 # --- 5. Stage non-provider-routed secrets for --upload (Finding K) ---------
 
@@ -190,6 +259,8 @@ timeout 600 openshell sandbox create \
   --name "$sandbox_name" \
   "${provider_args[@]}" \
   "${upload_args[@]}" \
+  --driver-config-json "$driver_config_json" \
+  "${sandbox_env_args[@]}" \
   --no-tty \
   -- sh -c "$wrapper" >/dev/null 2>&1 &
 create_pid=$!

--- a/bootc/rootfs/usr/libexec/tank-os/bootstrap-csb-sandbox
+++ b/bootc/rootfs/usr/libexec/tank-os/bootstrap-csb-sandbox
@@ -7,7 +7,7 @@ set -euo pipefail
 # systemd --user unit, not a Podman Quadlet -- CSB's own image is run via
 # `openshell sandbox create`, not `podman run` directly).
 #
-# Five jobs, all idempotent except the sandbox itself (recreated fresh on
+# Six jobs, all idempotent except the sandbox itself (recreated fresh on
 # every start -- Open Question 7's "no dependency on StartupResume"):
 #   1. Register the local gateway with the CLI, if it isn't already --
 #      required once per boot before any other `openshell` command below can
@@ -24,6 +24,11 @@ set -euo pipefail
 #      `openshell sandbox create` in the background and poll until the
 #      sandbox reports Ready (Finding L: the CLI's foreground attachment is
 #      cosmetic, not the supervised workload -- see step 7 below).
+#   6. (Runs between jobs 3 and 4 in the code, as step "4b" -- out of
+#      numeric sequence because it was added after the rest of this list
+#      was written) Mount a persistent Podman volume into the sandbox and
+#      point OpenClaw's state/workspace/model-catalog config at it, so
+#      that config survives job 5's recreation cycle.
 #
 # The sandbox's own overlay filesystem does NOT survive step 5's
 # delete/create cycle -- confirmed empirically, not just inferred: OpenClaw's
@@ -181,7 +186,13 @@ sandbox_env_args=(
 # OPENCLAW_PROVIDERS seeds the catalog declaratively on every sandbox
 # creation, so this gap can't reappear after a volume reset or fresh
 # install the way a one-off `openclaw config patch` would.
-if [[ "$openai_provider_attached" == true ]]; then
+#
+# Only seed the openai catalog when default_model actually names an openai
+# model -- openai_provider_attached and default_model are independent
+# signals (one from a secret's presence, the other from a build/runtime
+# override), so a future non-openai default with the openai secret still
+# present must not silently register a bogus id/name pair here.
+if [[ "$openai_provider_attached" == true && "$default_model" == openai/* ]]; then
   openai_model_id="${default_model#openai/}"
   openclaw_providers_json="$(printf '{"openai":{"api":"openai-responses","baseUrl":"https://api.openai.com/v1","models":[{"id":"%s","name":"%s"}]}}' \
     "$openai_model_id" "$openai_model_id")"


### PR DESCRIPTION
## Summary
- `bootstrap-csb-sandbox` deletes and recreates the CSB sandbox on every `openclaw.service` restart (by design, for supervision robustness — Finding L). This also destroys the sandbox's overlay filesystem, which silently wiped OpenClaw's own `~/.openclaw` config/session state on every restart — confirmed empirically during debugging, not just inferred.
- Following the upstream `openclaw-csb` demo runbook's own pattern, the sandbox now mounts a persistent named Podman volume (`tank-openclaw-data`) via `--driver-config-json`, and `OPENCLAW_STATE_DIR`/`OPENCLAW_WORKSPACE_DIR` point OpenClaw's config, session/auth store, and workspace at it — all of that now survives independently of the sandbox instance's own lifecycle.
- Also fixes a phantom default model (`openai/gpt-5.5`, inherited from the same upstream runbook — not a model OpenAI currently serves) by setting `OPENCLAW_DEFAULT_MODEL`/`OPENCLAW_PROVIDERS` declaratively on every sandbox creation, instead of requiring a manual `openclaw models set` + `config patch` that the persistence gap was silently discarding anyway.
- `OPENCLAW_DEFAULT_MODEL` is a new Containerfile `ARG`, matching `CSB_IMAGE_TAG`'s existing pattern, since a future OpenAI model rename is exactly the failure mode that caused this bug upstream.

## Test plan
- [x] `make build` / `make lint` — image builds cleanly, `bootc container lint` passes (10 checks, only pre-existing unrelated warnings)
- [x] Verified the Containerfile's `sed` substitution produces the correct `OPENCLAW_DEFAULT_MODEL` value in the built image
- [x] Spiked the mechanism against a disposable sandbox: wrote a marker file, deleted and recreated the sandbox with identical flags, confirmed the file (and OpenClaw's model config) survived
- [x] Live-patched the real `tank-csb` sandbox's `bootstrap-csb-sandbox` on a running dev VM (via the home-directory + systemd drop-in fallback, since `/usr` is read-only on this ostree system) and confirmed `openclaw models status` shows the correct default/configured model with zero manual patching
- [x] Full pre-ship check: `sudo make build && sudo make build-qcow2`, booted a **genuinely fresh VM**, confirmed `Configured models (1): openai/gpt-5.5-pro` on first boot with no manual steps at all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configured a default AI model for new sandbox environments.
  * Added persistent storage for OpenClaw settings and workspace data.
  * Automatically initializes the OpenAI model catalog when applicable.
  * Improved sandbox setup with clearer job documentation and environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->