### PR TITLE
fix: set SQLITE_TMPDIR for OpenClaw inside sandbox

### DIFF
--- a/bootc/rootfs/usr/libexec/tank-os/bootstrap-csb-sandbox
+++ b/bootc/rootfs/usr/libexec/tank-os/bootstrap-csb-sandbox
@@ -177,6 +177,7 @@ sandbox_env_args=(
   --env "OPENCLAW_STATE_DIR=${persist_mount_target}/.openclaw"
   --env "OPENCLAW_WORKSPACE_DIR=${persist_mount_target}/workspace"
   --env "OPENCLAW_DEFAULT_MODEL=${default_model}"
+  --env "SQLITE_TMPDIR=/tmp"
 )
 
 # OpenClaw's models.providers.<name>.models[] catalog has no entry for a


### PR DESCRIPTION
## Summary

- OpenClaw v2026.7.2 uses FTS5 (SQLite full-text search) for a new `standing_intents` feature. FTS5 creates temporary files during shadow table construction.
- Inside OpenShell sandboxes, Landlock restricts filesystem writes to `/sandbox` and `/tmp`. SQLite's default temp directory (`/var/tmp` or the database's own directory via internal fallback) isn't in the allowlist.
- This caused `openclaw gateway` to crash immediately on startup with `fts5: error creating shadow table standing_intents_fts_docsize: unable to open database file`, leaving the health-check timer in a restart loop that eventually orphaned containers.
- Fix: pass `SQLITE_TMPDIR=/tmp` as a sandbox environment variable so SQLite temp files land in a writable location.

## Test plan

- [x] Verified `openclaw gateway` starts and reaches `[gateway] ready` inside an OpenShell sandbox with `SQLITE_TMPDIR=/tmp`
- [x] Confirmed health-check (`curl http://127.0.0.1:18789/`) passes after fix
- [x] Confirmed the same gateway starts fine in plain `podman run` (no sandbox) without the fix, proving the issue is sandbox-specific

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox compatibility by configuring SQLite to use `/tmp` for temporary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->