### PR TITLE
fix: update CSB image tag to OpenClaw v2026.7.2-beta.7

### DIFF
--- a/bootc/Containerfile
+++ b/bootc/Containerfile
@@ -18,7 +18,7 @@ ARG OPENCLAW_SUBID_COUNT=65536
 # Pinned, date-stamped CSB tag -- see
 # docs/dev/csb-bootc-deployment-design.md Open Question 1. CSB rebuilds
 # daily; do not use csb-latest here.
-ARG CSB_IMAGE_TAG=quay.io/redhat-et/openclaw:csb-2026.07.21
+ARG CSB_IMAGE_TAG=quay.io/redhat-et/openclaw:csb-arm64-openclaw-v2026.7.2-beta.7
 
 # Default model for a fresh OpenClaw config. The upstream openclaw-csb demo
 # runbook's own pinned value (openai/gpt-5.5) turned out to no longer be a


### PR DESCRIPTION
## Summary

- Bump default `CSB_IMAGE_TAG` from `csb-2026.07.21` (v7.1) to `csb-arm64-openclaw-v2026.7.2-beta.7` with baked-in openshell plugin
- Eliminates need for the systemd override in `~/.config/systemd/user/openclaw.service.d/override.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default CSB container image to the pinned `csb-arm64-openclaw-v2026.7.2-beta.7` release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->