### PR TITLE
fix: update CSB image tag in Makefile and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ FEDORA_BOOTC_BASE ?=
 # Pinned, date-stamped CSB tag -- see
 # docs/dev/csb-bootc-deployment-design.md Open Question 1. CSB rebuilds
 # daily; do not default this to a moving tag like csb-latest.
-CSB_IMAGE_TAG ?= quay.io/redhat-et/openclaw:csb-2026.07.21
+CSB_IMAGE_TAG ?= quay.io/redhat-et/openclaw:csb-arm64-openclaw-v2026.7.2-beta.7
 # Single point of control for the OpenShell RPMs bootc/Containerfile
 # installs on the host -- its own ARG default exists only for standalone
 # builds run without this Makefile, and must be bumped together with

--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -43,7 +43,7 @@ and multi-instance notes.
 
 CSB's own image (`quay.io/redhat-et/openclaw:csb-<tag>`, pinned by the
 `CSB_IMAGE_TAG` build arg in `bootc/Containerfile` — the current default is
-`quay.io/redhat-et/openclaw:csb-2026.07.21`) is pulled as part of `openshell
+`quay.io/redhat-et/openclaw:csb-arm64-openclaw-v2026.7.2-beta.7`) is pulled as part of `openshell
 sandbox create --from`, which runs as `openclaw.service`'s `ExecStart` on
 every boot. There is no separate `podman pull` step in this flow the way
 there was for the old OpenClaw Quadlet — `openshell` manages the fetch
@@ -57,7 +57,7 @@ a no-op:
 ```bash
 ssh openclaw@<host>
 sudo -iu openclaw
-podman pull quay.io/redhat-et/openclaw:csb-2026.07.21
+podman pull quay.io/redhat-et/openclaw:csb-arm64-openclaw-v2026.7.2-beta.7
 systemctl --user restart openclaw.service
 ```
 


### PR DESCRIPTION
## Summary

- Update `CSB_IMAGE_TAG` in Makefile — this is what actually controls the build (overrides Containerfile's ARG default from PR #55)
- Update `docs/provisioning.md` pre-warm examples to match
- Design doc (`docs/dev/csb-bootc-deployment-design.md`) left unchanged — those references are historical findings from the Aug 5 validation spike

🤖 Generated with [Claude Code](https://claude.com/claude-code)