### PR TITLE
feat: enable openshell plugin by default in CSB sandbox

### DIFF
--- a/bootc/rootfs/usr/libexec/tank-os/bootstrap-csb-sandbox
+++ b/bootc/rootfs/usr/libexec/tank-os/bootstrap-csb-sandbox
@@ -178,6 +178,7 @@ sandbox_env_args=(
   --env "OPENCLAW_WORKSPACE_DIR=${persist_mount_target}/workspace"
   --env "OPENCLAW_DEFAULT_MODEL=${default_model}"
   --env "SQLITE_TMPDIR=/tmp"
+  --env 'OPENCLAW_ALLOWED_PLUGINS=["openshell"]'
 )
 
 # OpenClaw's models.providers.<name>.models[] catalog has no entry for a


### PR DESCRIPTION
## Summary

- Pass `OPENCLAW_ALLOWED_PLUGINS=["openshell"]` as a sandbox env var in `bootstrap-csb-sandbox`, enabling the openshell sandbox plugin on every fresh sandbox creation
- Without this, CSB policy disables all plugins by default — the plugin shows up in `openclaw plugins list` but is marked `disabled`

## Context

Completes the openshell-inside-CSB integration started in #54–#56. The plugin binary is already baked into the CSB image; this PR wires up the policy flag so it actually activates.

## Test plan

- [ ] Rebuild bootc image, recreate VM disk
- [ ] Verify `openclaw plugins list | grep openshell` shows `enabled`
- [ ] Run `openshell` from the OpenClaw TUI to confirm the sandbox backend works

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>