### PR TITLE
feat: expand OpenAI model catalog and default to gpt-5.6-luna

### DIFF
--- a/bootc/Containerfile
+++ b/bootc/Containerfile
@@ -24,7 +24,7 @@ ARG CSB_IMAGE_TAG=quay.io/redhat-et/openclaw:csb-arm64-openclaw-v2026.7.2-beta.7
 # runbook's own pinned value (openai/gpt-5.5) turned out to no longer be a
 # model OpenAI serves; re-pinning here should be a build-arg bump, not a
 # bootstrap-csb-sandbox edit.
-ARG OPENCLAW_DEFAULT_MODEL=openai/gpt-5.5-pro
+ARG OPENCLAW_DEFAULT_MODEL=openai/gpt-5.6-luna
 
 # OpenShell CLI + gateway RPMs, pinned to a tagged release rather than
 # `latest` for reproducible builds.

--- a/bootc/rootfs/usr/libexec/tank-os/bootstrap-csb-sandbox
+++ b/bootc/rootfs/usr/libexec/tank-os/bootstrap-csb-sandbox
@@ -188,16 +188,8 @@ sandbox_env_args=(
 # OPENCLAW_PROVIDERS seeds the catalog declaratively on every sandbox
 # creation, so this gap can't reappear after a volume reset or fresh
 # install the way a one-off `openclaw config patch` would.
-#
-# Only seed the openai catalog when default_model actually names an openai
-# model -- openai_provider_attached and default_model are independent
-# signals (one from a secret's presence, the other from a build/runtime
-# override), so a future non-openai default with the openai secret still
-# present must not silently register a bogus id/name pair here.
-if [[ "$openai_provider_attached" == true && "$default_model" == openai/* ]]; then
-  openai_model_id="${default_model#openai/}"
-  openclaw_providers_json="$(printf '{"openai":{"api":"openai-responses","baseUrl":"https://api.openai.com/v1","models":[{"id":"%s","name":"%s"}]}}' \
-    "$openai_model_id" "$openai_model_id")"
+if [[ "$openai_provider_attached" == true ]]; then
+  openclaw_providers_json='{"openai":{"api":"openai-responses","baseUrl":"https://api.openai.com/v1","models":[{"id":"gpt-5.6-luna","name":"gpt-5.6-luna"},{"id":"gpt-5.6-terra","name":"gpt-5.6-terra"},{"id":"gpt-5.6-sol","name":"gpt-5.6-sol"},{"id":"gpt-5.5-pro","name":"gpt-5.5-pro"}]}}'
   sandbox_env_args+=(--env "OPENCLAW_PROVIDERS=${openclaw_providers_json}")
 fi
 


### PR DESCRIPTION
## Summary

- Expand `OPENCLAW_PROVIDERS` in `bootstrap-csb-sandbox` to include four OpenAI models: gpt-5.6-luna, gpt-5.6-terra, gpt-5.6-sol, gpt-5.5-pro
- Change `OPENCLAW_DEFAULT_MODEL` build arg from `openai/gpt-5.5-pro` to `openai/gpt-5.6-luna` for faster default responses
- Simplify the provider-catalog guard: no longer needs `$default_model == openai/*` check since the model list is explicit

Previously `OPENCLAW_PROVIDERS` only seeded the single default model, so `openclaw models list` showed just one entry — users couldn't switch models without manual config edits that got overwritten on every restart.

## Test plan

- [ ] Rebuild bootc image, recreate VM disk
- [ ] Verify `openclaw models list` shows all four models
- [ ] Verify `gpt-5.6-luna` is marked as default
- [ ] Start a conversation and confirm luna responds

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>